### PR TITLE
GH Action to Build and Push a Docker Image

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           context: .
           file: ./config/containerdefinitions/btp-setup-automator/Dockerfile
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}          


### PR DESCRIPTION
This PR contains the GitHub Action to build and push a Docker Image based on the repository data.
It is triggered either manually or when a release is published for the repository.

**ATTENTION: Due to the repository being private there are restrictions for the free tier of packages, see <https://github.com/features/packages#pricing>**