### PR TITLE
Add form-based templates for issues and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,67 @@
+name: 🐞 Bug
+description: File a bug/issue
+title: "[BUG] <title>"
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: dropdown
+  id: area
+  attributes:
+    label: Which area is mainly impacted
+    options:
+    - Docker Image (Build or Run)
+    - CLI in general
+    - Cloud Foundry setups
+    - Kyma setups
+    - Documentation
+    - Security
+    - Other
+  validations:
+    required: true  
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Logs available?
+    description: |
+      Are there any logs available? If yes please post them here or attach them to this issue.
+
+      Tip: You can attach log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,48 @@
+name: 🚀 Feature Request
+description: File a Feature Request
+title: "[FEATURE REQUEST] <title>"
+labels: [enhancement]
+body:
+- type: dropdown
+  id: area
+  attributes:
+    label: Which area is mainly impacted
+    options:
+    - Docker Image (Build or Run)
+    - CLI in general
+    - Cloud Foundry setups
+    - Kyma setups
+    - Configuration
+    - Documentation
+    - Security
+    - Other
+  validations:
+    required: true  
+- type: textarea
+  attributes:
+    label: Requested Feature
+    description: A concise description of the feature you are currently missing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Use Case/Scenario
+    description: A concise description of the use-case and scenario where you are missing this feature.
+  validations:
+    required: false
+- type: checkboxes
+  attributes:
+    label: Would you like to support us?
+    description: Would you like to support us in developing this feature?
+    options:
+    - label: Yes, I would like to support you
+      required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the feature you would like to see!
+
+      Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false


### PR DESCRIPTION
This PR contains the configuration of from based templates for:

- bug reports
- feature requests

Other types of issues (i.e. free-style are switched off

It is using the form-based syntax provided by GitHub which is currently in beta ([Link](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)). This feature is currently only active for public repos, so we will see the templates once you switched the visibility of the repository to public

