### PR TITLE
Set repo sha in build

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           context: .
           file: ./config/containerdefinitions/btp-setup-automator/Dockerfile
+          build-args: BTPSETUPAUTOMATOR_VERSION_GIT=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}          


### PR DESCRIPTION
This PR contains an addition to the build to set the repo sha into the container via the env `BTPSETUPAUTOMATOR_VERSION_GIT`