### PR TITLE
Multi env support in one use case + support of catalog name for a service plan

### DIFF
--- a/config/containerdefinitions/btp-setup-automator/Dockerfile
+++ b/config/containerdefinitions/btp-setup-automator/Dockerfile
@@ -202,7 +202,7 @@ COPY --chown=$USERNAME:$USERNAME docs                                       $HOM
 COPY --chown=$USERNAME:$USERNAME libs/python/btpsa                          $HOME_FOLDER/
 COPY --chown=$USERNAME:$USERNAME libs/python/btp_cli.py                     $LIBS_FOLDER/python/
 COPY --chown=$USERNAME:$USERNAME libs/python/helper*.py                     $LIBS_FOLDER/python/
-COPY --chown=$USERNAME:$USERNAME libs/json/paramBtpSetupAutomator.json      $LIBS_FOLDER/json/
+COPY --chown=$USERNAME:$USERNAME libs/json                                  $LIBS_FOLDER/json/
 
 COPY --chown=$USERNAME:$USERNAME .reuse                                     $HOME_FOLDER/.reuse
 COPY --chown=$USERNAME:$USERNAME LICENSES                                   $HOME_FOLDER/LICENSES

--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -4,7 +4,10 @@ charset-normalizer==2.0.12
 flake8==4.0.1
 idna==3.3
 inquirer==2.9.1
+Jinja2==3.1.1
+MarkupSafe==2.1.1
 mccabe==0.6.1
+ninja2==0.1
 pycodestyle==2.8.0
 pyflakes==2.4.0
 python-dateutil==2.8.2

--- a/docs/PARAMETERS-BTPSA.md
+++ b/docs/PARAMETERS-BTPSA.md
@@ -1,0 +1,122 @@
+# Parameters that can be used when calling btp-setup-automator
+
+## Parameter name
+
+name of the service
+
+Type: str
+
+Mandatory: True
+
+Default: None
+
+## Parameter entitleonly
+
+if set to true, no service instances will be created by the tool
+
+Type: bool
+
+Mandatory: False
+
+Default: False
+
+## Parameter category
+
+category of the service
+
+Type: str
+
+Mandatory: True
+
+Default: None
+
+## Parameter createinenvironment
+
+environment in which the service should be created
+
+Type: str
+
+Mandatory: True
+
+Default: cloudfoundry
+
+## Parameter plan
+
+plan name of the service
+
+Type: str
+
+Mandatory: False
+
+Default: None
+
+## Parameter instancename
+
+name of the service
+
+Type: str
+
+Mandatory: False
+
+Default: None
+
+## Parameter parameters
+
+parameters for the service
+
+Type: dict
+
+Mandatory: False
+
+Default: None
+
+## Parameter amount
+
+amount to be used for the service
+
+Type: int
+
+Mandatory: False
+
+Default: None
+
+## Parameter repeatstatusrequest
+
+number of seconds when status should be checked
+
+Type: int
+
+Mandatory: False
+
+Default: 5
+
+## Parameter repeatstatustimeout
+
+timeout in seconds after which the script will stop checking the status
+
+Type: int
+
+Mandatory: False
+
+Default: 3600
+
+## Parameter createServiceKeys
+
+list of service keys to be created for a service 
+
+Type: array
+
+Mandatory: False
+
+Default: None
+
+## Parameter requiredrolecollections
+
+list of role collections to be created for a service
+
+Type: list
+
+Mandatory: False
+
+Default: None
+

--- a/docs/PARAMETERS-SERVICES.md
+++ b/docs/PARAMETERS-SERVICES.md
@@ -1,0 +1,122 @@
+# Parameters used for defining services
+
+## Parameter name
+
+name of the service
+
+Type: str
+
+Mandatory: True
+
+Default: None
+
+## Parameter entitleonly
+
+if set to true, no service instances will be created by the tool
+
+Type: bool
+
+Mandatory: False
+
+Default: False
+
+## Parameter category
+
+category of the service
+
+Type: str
+
+Mandatory: True
+
+Default: None
+
+## Parameter createinenvironment
+
+environment in which the service should be created
+
+Type: str
+
+Mandatory: True
+
+Default: cloudfoundry
+
+## Parameter plan
+
+plan name of the service
+
+Type: str
+
+Mandatory: False
+
+Default: None
+
+## Parameter instancename
+
+name of the service
+
+Type: str
+
+Mandatory: False
+
+Default: None
+
+## Parameter parameters
+
+parameters for the service
+
+Type: dict
+
+Mandatory: False
+
+Default: None
+
+## Parameter amount
+
+amount to be used for the service
+
+Type: int
+
+Mandatory: False
+
+Default: None
+
+## Parameter repeatstatusrequest
+
+number of seconds when status should be checked
+
+Type: int
+
+Mandatory: False
+
+Default: 5
+
+## Parameter repeatstatustimeout
+
+timeout in seconds after which the script will stop checking the status
+
+Type: int
+
+Mandatory: False
+
+Default: 3600
+
+## Parameter createServiceKeys
+
+list of service keys to be created for a service 
+
+Type: array
+
+Mandatory: False
+
+Default: None
+
+## Parameter requiredrolecollections
+
+list of role collections to be created for a service
+
+Type: list
+
+Mandatory: False
+
+Default: None
+

--- a/libs/json/createDocsForParemeters.py
+++ b/libs/json/createDocsForParemeters.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+import jinja2
+import json
+
+
+def getJsonFromFile(filename):
+    data = None
+    foundError = False
+    f = None
+
+    try:
+        # Opening JSON file
+        f = open(filename)
+        # returns JSON object as a dictionary
+        data = json.load(f)
+    except IOError:
+        message = "Can't open json file >" + filename + "<"
+        print(message)
+        foundError = True
+    except ValueError as err:
+        message = "There is an issue in the json file >" + filename + \
+            "<. Issue starts on character position " + \
+            str(err.pos) + ": " + err.msg
+
+        print(message)
+        foundError = True
+    finally:
+        if f is not None:
+            f.close()
+
+    if foundError is True:
+        message = "Can't run the use case before the error(s) mentioned above are not fixed"
+        print(message)
+    return data
+
+
+def renderTemplateWithJson(TEMPLATE_FILE):
+
+    templateLoader = jinja2.FileSystemLoader(searchpath="templates/")
+    templateEnv = jinja2.Environment(loader=templateLoader)
+    template = templateEnv.get_template(TEMPLATE_FILE)
+    parameters = getJsonFromFile("paramServices.json")
+
+    renderedText = template.render(params=parameters)  # this is where to put args to the template renderer
+
+    with open('../../docs/' + TEMPLATE_FILE, 'w') as f:
+        f.write(renderedText)
+
+
+renderTemplateWithJson("PARAMETERS-SERVICES.md")
+renderTemplateWithJson("PARAMETERS-BTPSA.md")

--- a/libs/json/paramServices.json
+++ b/libs/json/paramServices.json
@@ -20,7 +20,7 @@
         "mandatory": true,
         "help": "category of the service",
         "default": null,
-        "acceptedvalues":["SERVICE","APPLICATION","CF_CUP_SERVICE","ENVIRONMENT"]
+        "acceptedvalues":["SERVICE","APPLICATION","CF_CUP_SERVICE","ENVIRONMENT","PLATFORM"]
     },
     {
         "argument": "createinenvironment",
@@ -46,7 +46,7 @@
     },
     {
         "argument": "parameters",
-        "type": "str",
+        "type": "dict",
         "mandatory": false,
         "help": "parameters for the service",
         "default": null
@@ -81,7 +81,7 @@
     },
     {
         "argument": "requiredrolecollections",
-        "type": "array",
+        "type": "list",
         "mandatory": false,
         "help": "list of role collections to be created for a service",
         "default": null

--- a/libs/json/paramServices.json
+++ b/libs/json/paramServices.json
@@ -12,7 +12,10 @@
         "mandatory": false,
         "help": "if set to true, no service instances will be created by the tool",
         "default": false,
-        "acceptedvalues":[true, false]
+        "acceptedvalues": [
+            true,
+            false
+        ]
     },
     {
         "argument": "category",
@@ -20,21 +23,37 @@
         "mandatory": true,
         "help": "category of the service",
         "default": null,
-        "acceptedvalues":["SERVICE","APPLICATION","CF_CUP_SERVICE","ENVIRONMENT","PLATFORM"]
+        "acceptedvalues": [
+            "SERVICE",
+            "APPLICATION",
+            "CF_CUP_SERVICE",
+            "ENVIRONMENT",
+            "PLATFORM"
+        ]
     },
     {
-        "argument": "createinenvironment",
+        "argument": "targetenvironment",
         "type": "str",
         "mandatory": true,
         "help": "environment in which the service should be created",
         "default": "cloudfoundry",
-        "acceptedvalues":["cloudfoundry","kymaruntime"]
+        "acceptedvalues": [
+            "cloudfoundry",
+            "kymaruntime"
+        ]
     },
     {
         "argument": "plan",
         "type": "str",
         "mandatory": false,
         "help": "plan name of the service",
+        "default": null
+    },
+    {
+        "argument": "planforinstance",
+        "type": "str",
+        "mandatory": false,
+        "help": "catalog name of the service plan",
         "default": null
     },
     {

--- a/libs/json/paramServices.json
+++ b/libs/json/paramServices.json
@@ -93,7 +93,14 @@
     },
     {
         "argument": "createServiceKeys",
-        "type": "array",
+        "type": "list",
+        "mandatory": false,
+        "help": "list of service keys to be created for a service ",
+        "default": null
+    },
+    {
+        "argument": "requiredServices",
+        "type": "list",
         "mandatory": false,
         "help": "list of service keys to be created for a service ",
         "default": null

--- a/libs/json/paramServices.json
+++ b/libs/json/paramServices.json
@@ -50,7 +50,7 @@
         "default": null
     },
     {
-        "argument": "planforinstance",
+        "argument": "planCatalogName",
         "type": "str",
         "mandatory": false,
         "help": "catalog name of the service plan",

--- a/libs/json/templates/PARAMETERS-BTPSA.md
+++ b/libs/json/templates/PARAMETERS-BTPSA.md
@@ -1,0 +1,13 @@
+# Parameters that can be used when calling btp-setup-automator
+
+{% for param in params -%}## Parameter {{ param.argument }}
+
+{{ param.help }}
+
+Type: {{ param.type }}
+
+Mandatory: {{ param.mandatory }}
+
+Default: {{ param.default }}
+
+{% endfor %}

--- a/libs/json/templates/PARAMETERS-SERVICES.md
+++ b/libs/json/templates/PARAMETERS-SERVICES.md
@@ -1,0 +1,13 @@
+# Parameters used for defining services
+
+{% for param in params -%}## Parameter {{ param.argument }}
+
+{{ param.help }}
+
+Type: {{ param.type }}
+
+Mandatory: {{ param.mandatory }}
+
+Default: {{ param.default }}
+
+{% endfor %}

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -14,10 +14,12 @@ import sys
 import time
 import requests
 
+from libs.python.helperServices import readAllServicesFromUsecaseFile
+
 
 class BTPUSECASE:
     def __init__(self):
-        myArgs = helperArgParser.setup()
+        myArgs = helperArgParser.setupParamsBtpsa()
         # Take args and add them to self
         for arg in vars(myArgs):
             value = getattr(myArgs, arg)
@@ -44,12 +46,13 @@ class BTPUSECASE:
         self.definedServices = None
         self.accountMetadata = None
 
+        allServices = readAllServicesFromUsecaseFile(self)
+
+        self.definedServices = getServiceCategoryItemsFromUsecaseFile(self, ["SERVICE", "ELASTIC_SERVICE", "PLATFORM", "CF_CUP_SERVICE"])
+
         self.definedEnvironments = getServiceCategoryItemsFromUsecaseFile(self, ["ENVIRONMENT"])
         self.admins = getAdminsFromUsecaseFile(self)
-        self.btpEnvironment = setBtpEnvironment(self, self.definedEnvironments)
-        log.write(logtype.HEADER, "This use case will use the BTP environment >" + self.btpEnvironment["name"] + "<")
         self.definedAppSubscriptions = getServiceCategoryItemsFromUsecaseFile(self, ["APPLICATION"])
-        self.definedServices = getServiceCategoryItemsFromUsecaseFile(self, ["SERVICE", "ELASTIC_SERVICE", "PLATFORM", "CF_CUP_SERVICE"])
 
         ##############################################################################################
         # From here on, we have all the data together that we need to move ahead

--- a/libs/python/helperAccountInfo.py
+++ b/libs/python/helperAccountInfo.py
@@ -73,10 +73,10 @@ def createCSVForEntitledServicesInDatacenters(btpUsecase):
     string += "\n"
 
     result = []
-    for service in data["entitledServices"]:
-        string += service["name"] + ";" + service["displayName"] + ";"
-        serviceDCs = getDataCenterFromService(service)
-        myService = {"name": service["name"]}
+    for entitledService in data["entitledServices"]:
+        string += entitledService["name"] + ";" + entitledService["displayName"] + ";"
+        serviceDCs = getDataCenterFromService(entitledService)
+        myService = {"name": entitledService["name"]}
         for dc in dcsCF:
             if dc in serviceDCs:
                 myService[dc] = "X"

--- a/libs/python/helperArgParser.py
+++ b/libs/python/helperArgParser.py
@@ -4,11 +4,10 @@ from libs.python.helperLog import logtype
 import getpass
 
 
-def setup():
-    btpSetupAutomatorArguments = "libs/json/paramBtpSetupAutomator.json"
+def setupParams(myArguments):
     parser = argparse.ArgumentParser()
-    if btpSetupAutomatorArguments is not None and btpSetupAutomatorArguments != "":
-        allJsonParameters = getJsonFromFile(None, btpSetupAutomatorArguments)
+    if myArguments is not None and myArguments != "":
+        allJsonParameters = getJsonFromFile(None, myArguments)
 
         for parameter in allJsonParameters:
             argument = parameter["argument"]
@@ -16,20 +15,29 @@ def setup():
             help = parameter["help"]
             default = parameter["default"]
             if type == "str":
-                parser.add_argument('-' + argument, type=str,
-                                    help=help, default=default)
+                parser.add_argument('-' + argument, type=str, help=help, default=default)
             if type == "bool":
-                parser.add_argument('-' + argument, type=bool,
-                                    help=help, default=default)
+                parser.add_argument('-' + argument, type=bool, help=help, default=default)
             if type == "int":
-                parser.add_argument('-' + argument, type=int,
-                                    help=help, default=default)
+                parser.add_argument('-' + argument, type=int, help=help, default=default)
 
         args = parser.parse_args()
-        createDefaultParametersFile(btpSetupAutomatorArguments)
-        args = assignArgumentsThroughJsonParameterFile(args)
-        return args
+        myArgs = assignArgumentsThroughJsonParameterFile(args)
+        return myArgs
     return None
+
+
+def setupParamsBtpsa():
+    btpSetupAutomatorArguments = "libs/json/paramBtpSetupAutomator.json"
+    args = setupParams(btpSetupAutomatorArguments)
+    return args
+
+
+def setupParamsServices():
+    serviceArguments = "libs/json/paramServices.json"
+    args = setupParams(serviceArguments)
+
+    return args
 
 
 def assignArgumentsThroughJsonParameterFile(args):

--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -111,15 +111,17 @@ def try_until_cf_space_done(btpUsecase, command, message, spacename, search_ever
 def create_cf_service(btpUsecase, service):
     instancename = service.instancename
 
-    command = "cf create-service \"" + \
-        service.name + "\" \"" + service.plan + \
-        "\"  \"" + instancename + "\""
+    plan = service.plan
+
+    if service.planCatalogName is not None:
+        plan = service.planCatalogName
+
+    command = "cf create-service \"" + service.name + "\" \"" + plan + "\"  \"" + instancename + "\""
 
     if service.parameters is not None:
         thisParameter = dictToString(service.parameters)
         command += " -c '" + thisParameter + "'"
-    message = "Create instance >" + instancename + "< for service >" + \
-        service.name + "< and plan >" + service.plan + "<"
+    message = "Create instance >" + instancename + "< for service >" + service.name + "< and plan >" + plan + "<"
     runShellCommand(btpUsecase, command, logtype.INFO, message)
     return service
 

--- a/libs/python/helperGeneric.py
+++ b/libs/python/helperGeneric.py
@@ -8,10 +8,10 @@ def getTimingsForStatusRequest(btpUsecase, thisService):
     usecaseTimeout = btpUsecase.repeatstatustimeout
 
     # If the service has defined its own time to repeat a status request, take that time instead
-    if "repeatstatusrequest" in thisService:
-        search_every_x_seconds = int(thisService["repeatstatusrequest"])
-    if "repeatstatustimeout" in thisService:
-        usecaseTimeout = int(thisService["repeatstatustimeout"])
+    if thisService.repeatstatusrequest is not None:
+        search_every_x_seconds = thisService.repeatstatusrequest
+    if thisService.repeatstatustimeout is not None:
+        usecaseTimeout = thisService.repeatstatustimeout
 
     return search_every_x_seconds, usecaseTimeout
 

--- a/libs/python/helperGeneric.py
+++ b/libs/python/helperGeneric.py
@@ -18,7 +18,7 @@ def getTimingsForStatusRequest(btpUsecase, thisService):
 
 def getServiceByServiceName(btpUsecase, serviceName):
     for service in btpUsecase.definedServices:
-        if service["name"] == serviceName:
+        if service.name == serviceName:
             return service
     return None
 
@@ -71,11 +71,11 @@ def createSubaccountName(btpUsecase):
 
 def createInstanceName(btpUsecase, service):
     result = "instance"
-    if service["category"] != "CF_CUP_SERVICE":
-        if "instancename" in service:
-            return service["instancename"]
+    if service.category != "CF_CUP_SERVICE":
+        if service.instancename is not None:
+            return service.instancename
         else:
-            result = service["name"] + "_" + service["plan"] + "_" + btpUsecase.suffixinstancename
+            result = service.name + "_" + service.plan + "_" + btpUsecase.suffixinstancename
         result = re.sub(r"[^\w\s]", '_', result)
         result = result.replace("__", "_")
         if result[len(result) - 1] == "_":
@@ -83,8 +83,7 @@ def createInstanceName(btpUsecase, service):
 
         result = result[:40]
     else:
-        result += "_" + service["name"]
-
+        result += "_" + service.name
 
     return result
 

--- a/libs/python/helperServices.py
+++ b/libs/python/helperServices.py
@@ -1,0 +1,59 @@
+from libs.python.helperJson import getJsonFromFile
+from libs.python.helperLog import logtype
+import sys
+import os
+
+
+class BTPSERVICE:
+    def __init__(self, paramDefinitionServices, definedUsecaseService, btpUsecase):
+        log = btpUsecase.log
+        for parameter in paramDefinitionServices:
+            argument = parameter["argument"]
+            default = parameter["default"]
+            acceptedvalues = None
+            if "acceptedvalues" in parameter:
+                acceptedvalues = parameter["acceptedvalues"]
+            mandatory = parameter["mandatory"]
+            paramType = parameter["type"]
+
+            serviceName = "unknown"
+            if "name" in definedUsecaseService:
+                serviceName = definedUsecaseService["name"]
+
+            setattr(self, argument, default)
+
+            if argument in definedUsecaseService.keys():
+                value = definedUsecaseService[argument]
+                if acceptedvalues is not None and value not in acceptedvalues:
+                    message = "parameter >" + argument + "< for service >" + serviceName + "< was set to >" + value + "<, but allowed values are >" + str(acceptedvalues) + "<\nPlease correct the parameter!"
+                    log.write(logtype.ERROR, message)
+                    sys.exit(os.EX_DATAERR)
+                if mandatory is True and value is None:
+                    message = "parameter >" + argument + "< for service >" + serviceName + "< is mandatory, but was not set.\nPlease correct the parameter!"
+                    log.write(logtype.ERROR, message)
+                    sys.exit(os.EX_DATAERR)
+                typeParameter = type(value).__name__
+                if paramType != typeParameter:
+                    message = "parameter >" + argument + "< for service >" + serviceName + "< should be a >" + paramType + "<, but it's >" + typeParameter + "<\nPlease correct the parameter!"
+                    log.write(logtype.ERROR, message)
+                    sys.exit(os.EX_DATAERR)
+                setattr(self, argument, value)
+            else:
+                if mandatory is True and default is None:
+                    message = "parameter >" + argument + "< for service >" + serviceName + "< is mandatory, but was not set.\nPlease correct the parameter!"
+                    log.write(logtype.ERROR, message)
+                    sys.exit(os.EX_DATAERR)
+
+
+def readAllServicesFromUsecaseFile(btpUsecase):
+    # Initiate class with configured parameters
+    paramServicesFile = "libs/json/paramServices.json"
+    paramDefinitionServices = getJsonFromFile(None, paramServicesFile)
+
+    usecase = getJsonFromFile(btpUsecase, btpUsecase.usecasefile)
+    items = []
+    if "services" in usecase:
+        for usecaseService in usecase["services"]:
+            service = BTPSERVICE(paramDefinitionServices, usecaseService, btpUsecase)
+            items.append(service)
+    return items

--- a/libs/python/helperServices.py
+++ b/libs/python/helperServices.py
@@ -2,6 +2,7 @@ from libs.python.helperJson import getJsonFromFile
 from libs.python.helperLog import logtype
 import sys
 import os
+from json import JSONEncoder
 
 
 class BTPSERVICE:
@@ -43,6 +44,12 @@ class BTPSERVICE:
                     message = "parameter >" + argument + "< for service >" + serviceName + "< is mandatory, but was not set.\nPlease correct the parameter!"
                     log.write(logtype.ERROR, message)
                     sys.exit(os.EX_DATAERR)
+
+
+# subclass JSONEncoder
+class BTPSERVICEEncoder(JSONEncoder):
+    def default(self, o):
+        return o.__dict__
 
 
 def readAllServicesFromUsecaseFile(btpUsecase):

--- a/usecases/other/discoverycenter/3774-taskcenter/usecase.json
+++ b/usecases/other/discoverycenter/3774-taskcenter/usecase.json
@@ -13,8 +13,6 @@
       "plan": "apiaccess",
       "instancename": "xsuaa_api",
       "category": "SERVICE",
-      "repeatstatusrequest": "5",
-      "repeatstatustimeout": "200",
       "createServiceKeys": [
         "myServiceKey1"
       ]

--- a/usecases/other/inDevelopment/free_tier_services.json
+++ b/usecases/other/inDevelopment/free_tier_services.json
@@ -11,8 +11,8 @@
       "name": "hana-cloud",
       "plan": "hana-free",
       "category": "SERVICE",
-      "repeatstatusrequest": "60",
-      "repeatstatustimeout": "3600",
+      "repeatstatusrequest": 60,
+      "repeatstatustimeout": 3600,
       "instancename": "hana_instance",
       "parameters": {
         "data": {

--- a/usecases/other/inDevelopment/kyma-mission.json
+++ b/usecases/other/inDevelopment/kyma-mission.json
@@ -23,11 +23,13 @@
         {
             "name": "destination",
             "plan": "lite",
+            "entitleonly": true,
             "category": "SERVICE"
         },
         {
             "name": "xsuaa",
             "plan": "broker",
+            "entitleonly": true,
             "category": "SERVICE"
         },
         {

--- a/usecases/other/inDevelopment/kyma-mission.json
+++ b/usecases/other/inDevelopment/kyma-mission.json
@@ -1,0 +1,66 @@
+{
+    "aboutThisUseCase": {
+        "name": "Develop a Multitenant Extension Application in SAP BTP, Kyma Runtime",
+        "description": "This project contains a reference application, showcasing an end-to-end development scenario for a multitenant extension on SAP BTP Kyma runtime, which has an SAP partner as focus persona.",
+        "author": "alexander.rieder@sap.com",
+        "testStatus": "tested successfully",
+        "usageStatus": "READY TO BE USED",
+        "relatedLinks": [
+            "https://github.com/SAP-samples/btp-kyma-multitenant-extension"
+        ]
+    },
+    "services": [
+        {
+            "category": "ENVIRONMENT",
+            "name": "kymaruntime",
+            "plan": "free",
+            "amount": 1,
+            "parameters": {
+                "name": "btp-auto-setup",
+                "region": "eu-central-1"
+            }
+        },
+        {
+            "name": "destination",
+            "plan": "lite",
+            "category": "SERVICE"
+        },
+        {
+            "name": "xsuaa",
+            "plan": "broker",
+            "category": "SERVICE"
+        },
+        {
+            "name": "hana-cloud",
+            "plan": "hana-free",
+            "category": "SERVICE",
+            "repeatstatusrequest": 60,
+            "repeatstatustimeout": 3600,
+            "instancename": "hana-cloud",
+            "parameters": {
+                "data": {
+                    "edition": "cloud",
+                    "memory": 30,
+                    "serviceStopped": false,
+                    "storage": 120,
+                    "systempassword": "mySAP123",
+                    "vcpu": 0,
+                    "versionIndicator": "",
+                    "whitelistIPs": [
+                        "0.0.0.0/0"
+                    ]
+                }
+            }
+        }
+    ],
+    "admins": [
+        "alexander.rieder@sap.com",
+        "clemens.fehr@sap.com"
+    ],
+    "executeAfterAccountSetup": [
+        {
+            "description": "Get the tutorial code",
+            "command": "rm -rf /home/user/tutorial && git clone https://github.com/SAP-samples/s4hana-btp-extension-devops /home/user/tutorial && cd /home/user/tutorial/ "
+        }
+    ]
+}

--- a/usecases/other/inDevelopment/kyma-mission.json
+++ b/usecases/other/inDevelopment/kyma-mission.json
@@ -55,10 +55,7 @@
             }
         }
     ],
-    "admins": [
-        "alexander.rieder@sap.com",
-        "clemens.fehr@sap.com"
-    ],
+    "admins": [],
     "executeAfterAccountSetup": [
         {
             "description": "Get the tutorial code",

--- a/usecases/other/inDevelopment/redis.json
+++ b/usecases/other/inDevelopment/redis.json
@@ -1,0 +1,19 @@
+{
+    "aboutThisUseCase": {
+        "name": "Setup Redis",
+        "description": "This usecase sets up Redis",
+        "author": "rui.nogueira@sap.com",
+        "testStatus": "tested",
+        "usageStatus": "Not READY TO BE USED",
+        "relatedLinks": []
+    },
+    "services": [
+        {
+            "category": "SERVICE",
+            "name": "redis",
+            "plan": "dev",
+            "planforinstance": "v4.0-dev",
+            "instancename": "test-redis"
+        }
+    ]
+}

--- a/usecases/other/inDevelopment/setup_ci-cd.json
+++ b/usecases/other/inDevelopment/setup_ci-cd.json
@@ -11,8 +11,8 @@
             "name": "cicd-app",
             "plan": "free",
             "category": "APPLICATION",
-            "repeatstatusrequest": "5",
-            "repeatstatustimeout": "200",
+            "repeatstatusrequest": 5,
+            "repeatstatustimeout": 200,
             "requiredrolecollections": [
                 "CICD Service Administrator"
             ]

--- a/usecases/other/unittests/usecase_ut02_one_subscription_only.json
+++ b/usecases/other/unittests/usecase_ut02_one_subscription_only.json
@@ -12,8 +12,8 @@
             "name": "SAPLaunchpad",
             "plan": "standard",
             "category": "APPLICATION",
-            "repeatstatusrequest": "10",
-            "repeatstatustimeout": "120",
+            "repeatstatusrequest": 10,
+            "repeatstatustimeout": 120,
             "requiredrolecollections": [
                 "Launchpad_Admin"
             ]

--- a/usecases/released/cap_app_launchpad.json
+++ b/usecases/released/cap_app_launchpad.json
@@ -19,8 +19,8 @@
       "category": "SERVICE",
       "name": "hana-cloud",
       "plan": "hana-free",
-      "repeatstatusrequest": "60",
-      "repeatstatustimeout": "3600",
+      "repeatstatusrequest": 60,
+      "repeatstatustimeout": 3600,
       "instancename": "my-hana-cloud-free-instance",
       "parameters": {
         "data": {

--- a/usecases/released/cap_app_launchpad_TRIAL.json
+++ b/usecases/released/cap_app_launchpad_TRIAL.json
@@ -26,8 +26,8 @@
       "name": "hana-cloud-trial",
       "plan": "hana",
       "instancename": "hana_cloud_instance",
-      "repeatstatusrequest": "60",
-      "repeatstatustimeout": "3600",
+      "repeatstatusrequest": 60,
+      "repeatstatustimeout": 3600,
       "parameters": {
         "data": {
           "edition": "cloud",

--- a/usecases/released/extendS4_with_devops.json
+++ b/usecases/released/extendS4_with_devops.json
@@ -39,8 +39,8 @@
             "name": "hana-cloud",
             "plan": "hana-free",
             "category": "SERVICE",
-            "repeatstatusrequest": "60",
-            "repeatstatustimeout": "3600",
+            "repeatstatusrequest": 60,
+            "repeatstatustimeout": 3600,
             "instancename": "hana-cloud",
             "parameters": {
                 "data": {

--- a/usecases/released/setup_ABAP_steampunk.json
+++ b/usecases/released/setup_ABAP_steampunk.json
@@ -12,8 +12,8 @@
             "name": "abap",
             "plan": "free",
             "category": "SERVICE",
-            "repeatstatusrequest": "300",
-            "repeatstatustimeout": "7200",
+            "repeatstatusrequest": 300,
+            "repeatstatustimeout": 7200,
             "parameters": {
                 "admin_email": "your.emailaddress@somewhere.com",
                 "description": "Main development system",

--- a/usecases/released/setup_ias.json
+++ b/usecases/released/setup_ias.json
@@ -12,8 +12,8 @@
       "plan": "apiaccess",
       "instancename": "xsuaa_api",
       "category": "SERVICE",
-      "repeatstatusrequest": "5",
-      "repeatstatustimeout": "200",
+      "repeatstatusrequest": 5,
+      "repeatstatustimeout": 200,
       "createServiceKeys": [
         "myServiceKey1"
       ]


### PR DESCRIPTION
With this PR the btp-setup-automator can run use case configurations that need more than one BTP environment. This allows e.g. to setup Kyma as well as the Cloud Foundry environment to create service instances.

In addition this PR fixes as well the bug mentioned in at https://github.com/SAP-samples/btp-setup-automator/issues/28 .