### PR TITLE
Setup of integration tests via GH Actions

### DIFF
--- a/.github/workflows/integration-test-full.yml
+++ b/.github/workflows/integration-test-full.yml
@@ -1,0 +1,51 @@
+name: BTP Setup Automator - Integration Test (Full version - all released scenarios, non-trial)
+# This file represents a slim version of the "BTP Setup Automator" integration tests
+# All tests are executed in sequence on one BTP account to avoid entitlement limits
+# This is why not matrix strategy is used
+
+on:
+  workflow_dispatch:
+
+jobs:
+    integration-test:
+        runs-on: ubuntu-latest
+        container:
+          image: ghcr.io/sap-samples/btp-setup-automator:main
+          options: --user root
+        env: 
+            BTPSA_PARAM_MYEMAIL: ${{ secrets.BTPSA_PARAM_MYEMAIL }}
+            BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
+            BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
+        steps:
+            - name: 'Integration test 02: Deploy full-stack CAP application running in SAP Launchpad'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'
+            - name: 'Integration test 03: Extend SAP S/4HANA Business Processes on SAP BTP by Leveraging DevOps'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest03.json'
+            - name: 'Integration test 04: Only app subscriptions'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest04.json'
+            - name: 'Integration test 05: Only one service without app subscriptions and with an admin, that is the same like the one logging into the script.'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest05.json'
+            - name: 'Integration test 06: Create service keys'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'
+            - name: 'Integration test 07: Setup SAP Task Center"'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest07.json'
+            - name: 'Integration test 09: Setup a Kyma environment (Free Tier)'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest09.json'
+            - name: 'Integration test 10: Setup a Kyma environment on GCP'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest10.json'

--- a/.github/workflows/integration-test-slim.yml
+++ b/.github/workflows/integration-test-slim.yml
@@ -1,0 +1,31 @@
+name: BTP Setup Automator - Integration Test (Slim version - only main scenarios)
+# This file represents a slim version of the "BTP Setup Automator" integration tests
+# All tests are executed in sequence on one BTP account to avoid entitlement limits
+# This is why not matrix strategy is used
+
+on:
+  workflow_dispatch:
+
+jobs:
+    integration-test:
+        runs-on: ubuntu-latest
+        container:
+          image: ghcr.io/sap-samples/btp-setup-automator:main
+          options: --user root
+        env: 
+            BTPSA_PARAM_MYEMAIL: ${{ secrets.BTPSA_PARAM_MYEMAIL }}
+            BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
+            BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
+        steps:
+            - name: 'Integration test 04: Only app subscriptions'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest04.json'
+            - name: 'Integration test 05: Only one service without app subscriptions and with an admin, that is the same like the one logging into the script.'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest05.json'
+            - name: 'Integration test 06: create service keys'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'

--- a/integrationtests/parameterfiles/integrationtest01.json
+++ b/integrationtests/parameterfiles/integrationtest01.json
@@ -1,5 +1,5 @@
 {
-  "usecasefile": "usecases/released/cap_app_launchpad_TRIAL.json",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/cap_app_launchpad_TRIAL.json",
   "loginmethod": "basicAuthentication",
   "globalaccount": "86f7b91dtrial-ga",
   "prunesubaccount": true

--- a/integrationtests/parameterfiles/integrationtest02.json
+++ b/integrationtests/parameterfiles/integrationtest02.json
@@ -1,5 +1,5 @@
 {
-  "usecasefile": "usecases/released/cap_app_launchpad.json",
-  "loginmethod": "basicAuthentication",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/cap_app_launchpad.json",
+  "loginmethod": "envVariables",
   "prunesubaccount": true
 }

--- a/integrationtests/parameterfiles/integrationtest03.json
+++ b/integrationtests/parameterfiles/integrationtest03.json
@@ -1,5 +1,5 @@
 {
-  "usecasefile": "usecases/released/extendS4_with_devops.json",
-  "loginmethod": "basicAuthentication",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/extendS4_with_devops.json",
+  "loginmethod": "envVariables",
   "prunesubaccount": true
 }

--- a/integrationtests/parameterfiles/integrationtest04.json
+++ b/integrationtests/parameterfiles/integrationtest04.json
@@ -1,6 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it04_one_subscription_only.json",
-  "loginmethod": "basicAuthentication",
+  "loginmethod": "envVariables",
   "region": "us10",
   "subaccountname": "My own subacccount name",
   "subdomain": "my own subdomain with -",

--- a/integrationtests/parameterfiles/integrationtest05.json
+++ b/integrationtests/parameterfiles/integrationtest05.json
@@ -1,6 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it05_one_service_only.json",
-  "loginmethod": "basicAuthentication",
+  "loginmethod": "envVariables",
   "region": "eu10",
   "subaccountname": "My own subacccount name",
   "subdomain": "my own subdomain with -",

--- a/integrationtests/parameterfiles/integrationtest06.json
+++ b/integrationtests/parameterfiles/integrationtest06.json
@@ -1,5 +1,5 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it06_service_key_creation.json",
-  "loginmethod": "basicAuthentication",
+  "loginmethod": "envVariables",
   "prunesubaccount": true
 }

--- a/integrationtests/parameterfiles/integrationtest07.json
+++ b/integrationtests/parameterfiles/integrationtest07.json
@@ -1,5 +1,5 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_task_center.json",
-  "loginmethod": "basicAuthentication",
+  "loginmethod": "envVariables",
   "prunesubaccount": true
 }

--- a/integrationtests/parameterfiles/integrationtest08.json
+++ b/integrationtests/parameterfiles/integrationtest08.json
@@ -1,5 +1,5 @@
 {
-  "usecasefile": "usecases/released/setup_kyma_TRIAL.json",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_TRIAL.json",
   "loginmethod": "basicAuthentication",
   "subaccountname": "kymasetupauto",
   "region": "us10"

--- a/integrationtests/parameterfiles/integrationtest09.json
+++ b/integrationtests/parameterfiles/integrationtest09.json
@@ -1,5 +1,8 @@
 {
-  "usecasefile": "usecases/released/setup_kyma_free_tier.json",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_free_tier.json",
+  "loginmethod": "envVariables",
   "subaccountname": "kymasetupauto",
-  "region": "eu10"
+  "region": "eu10",
+  "pruneusecase": true,
+  "prunesubaccount": true
 }

--- a/integrationtests/parameterfiles/integrationtest10.json
+++ b/integrationtests/parameterfiles/integrationtest10.json
@@ -1,5 +1,8 @@
 {
-    "usecasefile": "usecases/released/setup_kyma_gcp.json",
+    "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_gcp.json",
+    "loginmethod": "envVariables",
     "subaccountname": "kymasetupauto",
-    "region": "us30"
-}
+    "region": "us30",
+    "pruneusecase": true,
+    "prunesubaccount": true
+  }

--- a/integrationtests/parameterfiles/integrationtest11.json
+++ b/integrationtests/parameterfiles/integrationtest11.json
@@ -1,5 +1,6 @@
 {
-    "usecasefile": "usecases/released/setup_kyma_gcp.json",
+    "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_gcp_with_dapr.json",
+    "loginmethod": "envVariables",
     "subaccountname": "kymasetupauto",
     "region": "us30",
     "waitForKymaEnvironmentCreation": true,


### PR DESCRIPTION
## Content

This PR contains the changes to setup integration tests via GitHub Actions:

- Reduced set of integration tests via `integration-test-slim.yml`
- Full set of integration tests via `integration-test-full.yml`

## Remarks;

- Trial scenarios are not considered in the automated tests
- The Kyma scenario with component installation is omitted due to runtime

## Necessary manual actions:

The following secrets must be created in the repository:
- BTPSA_PARAM_MYEMAIL: Email that should be used for execution of integration tests
- BTPSA_PARAM_GLOBALACCOUNT: Global account ID that should be used for integration tests
- BTPSA_PARAM_MYPASSWORD: Password that should be used for logon to SAP BTP
