### PR TITLE
apply common pattern for global account names (integration tests)

### DIFF
--- a/.github/workflows/integration-test-slim.yml
+++ b/.github/workflows/integration-test-slim.yml
@@ -29,3 +29,7 @@ jobs:
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'
+            - name: 'Integration test 02: deploy cap app on SAP Launchpad'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'              

--- a/.github/workflows/integration-test-slim.yml
+++ b/.github/workflows/integration-test-slim.yml
@@ -17,6 +17,10 @@ jobs:
             BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
             BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
         steps:
+            - name: 'Integration test 02: Deploy full-stack CAP application running in SAP Launchpad'
+              working-directory: /home/user
+              shell: bash 
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'              
             - name: 'Integration test 04: Only app subscriptions'
               working-directory: /home/user
               shell: bash 
@@ -29,7 +33,3 @@ jobs:
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'
-            - name: 'Integration test 02: deploy cap app on SAP Launchpad'
-              working-directory: /home/user
-              shell: bash 
-              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'              

--- a/integrationtests/parameterfiles/integrationtest01.json
+++ b/integrationtests/parameterfiles/integrationtest01.json
@@ -1,6 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/cap_app_launchpad_TRIAL.json",
   "loginmethod": "basicAuthentication",
-  "globalaccount": "86f7b91dtrial-ga",
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test cap app TRIAL"
 }

--- a/integrationtests/parameterfiles/integrationtest02.json
+++ b/integrationtests/parameterfiles/integrationtest02.json
@@ -1,5 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/cap_app_launchpad.json",
   "loginmethod": "envVariables",
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test cap app"
 }

--- a/integrationtests/parameterfiles/integrationtest03.json
+++ b/integrationtests/parameterfiles/integrationtest03.json
@@ -1,5 +1,7 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/extendS4_with_devops.json",
   "loginmethod": "envVariables",
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test s4 devops"
+
 }

--- a/integrationtests/parameterfiles/integrationtest04.json
+++ b/integrationtests/parameterfiles/integrationtest04.json
@@ -2,7 +2,7 @@
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it04_one_subscription_only.json",
   "loginmethod": "envVariables",
   "region": "us10",
-  "subaccountname": "My own subacccount name",
+  "subaccountname": "BTPSA int-test subscription",
   "subdomain": "my own subdomain with -",
   "cfspacename": "development",
   "suffixinstancename": "my own suffix",

--- a/integrationtests/parameterfiles/integrationtest05.json
+++ b/integrationtests/parameterfiles/integrationtest05.json
@@ -2,7 +2,7 @@
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it05_one_service_only.json",
   "loginmethod": "envVariables",
   "region": "eu10",
-  "subaccountname": "My own subacccount name",
+  "subaccountname": "BTPSA int-test one service",
   "subdomain": "my own subdomain with -",
   "cfspacename": "development",
   "suffixinstancename": "my own suffix",

--- a/integrationtests/parameterfiles/integrationtest06.json
+++ b/integrationtests/parameterfiles/integrationtest06.json
@@ -1,5 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/usecasefiles/usecase_it06_service_key_creation.json",
   "loginmethod": "envVariables",
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test service keys"
 }

--- a/integrationtests/parameterfiles/integrationtest07.json
+++ b/integrationtests/parameterfiles/integrationtest07.json
@@ -1,5 +1,6 @@
 {
-  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_task_center.json",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/discoverycenter/3774-taskcenter/usecase.json",
   "loginmethod": "envVariables",
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test disco task center"
 }

--- a/integrationtests/parameterfiles/integrationtest08.json
+++ b/integrationtests/parameterfiles/integrationtest08.json
@@ -1,6 +1,6 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_TRIAL.json",
   "loginmethod": "basicAuthentication",
-  "subaccountname": "kymasetupauto",
-  "region": "us10"
+  "region": "us10",
+  "subaccountname": "BTPSA int-test kymasetupauto TRIAL"
 }

--- a/integrationtests/parameterfiles/integrationtest09.json
+++ b/integrationtests/parameterfiles/integrationtest09.json
@@ -1,8 +1,8 @@
 {
   "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_free_tier.json",
   "loginmethod": "envVariables",
-  "subaccountname": "kymasetupauto",
   "region": "eu10",
   "pruneusecase": true,
-  "prunesubaccount": true
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test kymasetupauto free tier"
 }

--- a/integrationtests/parameterfiles/integrationtest10.json
+++ b/integrationtests/parameterfiles/integrationtest10.json
@@ -1,8 +1,8 @@
 {
-    "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_gcp.json",
-    "loginmethod": "envVariables",
-    "subaccountname": "kymasetupauto",
-    "region": "us30",
-    "pruneusecase": true,
-    "prunesubaccount": true
-  }
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_gcp.json",
+  "loginmethod": "envVariables",
+  "region": "us30",
+  "pruneusecase": true,
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test kymasetupauto gcp"
+}

--- a/integrationtests/parameterfiles/integrationtest11.json
+++ b/integrationtests/parameterfiles/integrationtest11.json
@@ -1,9 +1,9 @@
 {
     "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/setup_kyma_gcp_with_dapr.json",
     "loginmethod": "envVariables",
-    "subaccountname": "kymasetupauto",
     "region": "us30",
     "waitForKymaEnvironmentCreation": true,
     "timeoutLimitForKymaCreationInMinutes": 35,
-    "pollingIntervalForKymaCreationInMinutes": 5
+    "pollingIntervalForKymaCreationInMinutes": 5,
+    "subaccountname": "BTPSA int-test kymasetupauto gcp dapr"
 }


### PR DESCRIPTION
This pull request is focusing on a common name pattern for global account names during the execution of integration tests.

The global accounts will all be called `BTPSA int-test xxxx` where xxxx describes very briefly what the focus of the specific integration test is.