### PR TITLE
Remove hardcoded CF org name

### DIFF
--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -29,7 +29,7 @@ def checkIfCFEnvironmentAlreadyExists(btpUsecase):
 
     if "orgid" in accountMetadata:
         orgid = accountMetadata["orgid"]
-        nameOfEnvInstance = accountMetadata["subdomain"] + "_cloudfoundry"
+        nameOfEnvInstance = accountMetadata["subdomain"]
         org = None
 
         for instance in result["environmentInstances"]:


### PR DESCRIPTION
As discussed, remove hardcoded cf environment name "_cloudfoundry".
**You might need to adjust your use case files if you relied on this hardcoded approach.**