### PR TITLE
Execute steps independent of status of previous one

### DIFF
--- a/.github/workflows/integration-test-full.yml
+++ b/.github/workflows/integration-test-full.yml
@@ -2,6 +2,7 @@ name: BTP Setup Automator - Integration Test (Full version - all released scenar
 # This file represents a slim version of the "BTP Setup Automator" integration tests
 # All tests are executed in sequence on one BTP account to avoid entitlement limits
 # This is why not matrix strategy is used
+# The steps of a job must execute in any case, so we use always()
 
 on:
   workflow_dispatch:
@@ -18,34 +19,42 @@ jobs:
             BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
         steps:
             - name: 'Integration test 02: Deploy full-stack CAP application running in SAP Launchpad'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'
             - name: 'Integration test 03: Extend SAP S/4HANA Business Processes on SAP BTP by Leveraging DevOps'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest03.json'
             - name: 'Integration test 04: Only app subscriptions'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest04.json'
             - name: 'Integration test 05: Only one service without app subscriptions and with an admin, that is the same like the one logging into the script.'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest05.json'
             - name: 'Integration test 06: Create service keys'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'
             - name: 'Integration test 07: Setup SAP Task Center"'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest07.json'
             - name: 'Integration test 09: Setup a Kyma environment (Free Tier)'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest09.json'
             - name: 'Integration test 10: Setup a Kyma environment on GCP'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest10.json'

--- a/.github/workflows/integration-test-slim.yml
+++ b/.github/workflows/integration-test-slim.yml
@@ -2,6 +2,7 @@ name: BTP Setup Automator - Integration Test (Slim version - only main scenarios
 # This file represents a slim version of the "BTP Setup Automator" integration tests
 # All tests are executed in sequence on one BTP account to avoid entitlement limits
 # This is why not matrix strategy is used
+# The steps of a job must execute in any case, so we use always()
 
 on:
   workflow_dispatch:
@@ -18,18 +19,22 @@ jobs:
             BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
         steps:
             - name: 'Integration test 02: Deploy full-stack CAP application running in SAP Launchpad'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest02.json'              
             - name: 'Integration test 04: Only app subscriptions'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest04.json'
             - name: 'Integration test 05: Only one service without app subscriptions and with an admin, that is the same like the one logging into the script.'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest05.json'
             - name: 'Integration test 06: create service keys'
+              if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
               run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/integrationtests/parameterfiles/integrationtest06.json'


### PR DESCRIPTION
This PR contains the fix to execute the  single steps in the integration test independent of the status of the previous step.