### PR TITLE
Fix targeting existing space during cf login

### DIFF
--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -35,8 +35,8 @@ def login_cf(btpUsecase):
             ".hana.ondemand.com\" -o \"" + org + "\" -u \"" + \
             myemail + "\" -p \"" + password + "\""
     # If a space is already there, attach the space name to the login to target the space
-    if "cfspacename" in accountMetadata and accountMetadata["cfspacename"] is not None and accountMetadata["cfspacename"] != "":
-        command = "cf target -s \"" + accountMetadata["cfspacename"] + "\""
+    if btpUsecase.cfspacename is not None and btpUsecase.cfspacename != "":
+        command += " -s \"" + btpUsecase.cfspacename + "\""
     runShellCommandFlex(btpUsecase, command, "INFO", "Logging-in to your CF environment in the org >" + org + "< for your user >" + myemail + "<", True, pipe)
 
 


### PR DESCRIPTION
This solves the issue I've been having with cf login, while having specified an already existing cfspacename in parameters.json.