### PR TITLE
Added option to avoid exit on command execution error

### DIFF
--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -188,9 +188,13 @@ def executeCommandsFromUsecaseFile(btpUsecase, message, jsonSection):
             if "description" in command and "command" in command:
                 message = command["description"]
                 thisCommand = command["command"]
+                if "exitIfError" in command:
+                    exitIfError = command["exitIfError"]
+                else:
+                    exitIfError = True
                 log.header("COMMAND EXECUTION: " + message)
 
-                p = runShellCommandFlex(btpUsecase, thisCommand, "INFO", "Executing the following commands:\n" + thisCommand + "\n", True, True)
+                p = runShellCommandFlex(btpUsecase, thisCommand, "INFO", "Executing the following commands:\n" + thisCommand + "\n", exitIfError, True)
                 if p is not None and p.stdout is not None:
                     result = p.stdout.decode()
                     log.success(result)

--- a/usecases/other/dsag/2022-technologydays/README.md
+++ b/usecases/other/dsag/2022-technologydays/README.md
@@ -1,0 +1,58 @@
+# Instructions for setting up DSAG Technology Days hands-on in btp-setup-automator
+
+The [btp-setup-automator](https://github.com/SAP-samples/btp-setup-automator) is an open source project to help developers setting-up their SAP BTP accounts quickly via various command line interfaces.
+
+## Pre-Requisites
+
+To use the [btp-setup-automator](https://github.com/SAP-samples/btp-setup-automator) you first need to finish the following tasks:
+
+- Get an [SAP BTP trial account](https://cockpit.hanatrial.ondemand.com/trial/#/home/trial) or a [productive SAP BTP account](https://account.hana.ondemand.com/#/home/welcome) (recommended) where you can make use of the free tier service plans
+- [Install a Docker engine](https://docs.docker.com/desktop/)
+
+> ⚠ NOTE: Be aware of the terms of Docker for usage in enterprises. For details see this [link](https://www.docker.com/blog/updating-product-subscriptions/).
+
+## Context
+
+The files in this folder are linked to the hands-on tutorial that will be presented at DSAG Technology Days 2022. You find the complete description in the SAP Samples repository ["Kyma Runtime Extension"](https://github.com/SAP-samples/kyma-runtime-extension-samples/tree/main/dsagtt22).
+
+One component of this hands-on is the setup of the SAP Event Mesh as described in [step 4](https://github.com/SAP-samples/kyma-runtime-extension-samples/blob/main/dsagtt22/tutorial/step4.md) of the hands-on. The files in this directory contain the use case and the parameter files needed to do an automatic setup of this step.  
+
+## Instructions
+
+Open a command line terminal on your machine.
+
+> 📝 Tip - In case you don't know how to do it, here are the instructions for [MS Windows](https://www.wikihow.com/Open-Terminal-in-Windows), [Mac OS](https://www.wikihow.com/Open-a-Terminal-Window-in-Mac) and [Ubuntu Linux](https://www.wikihow.com/Open-a-Terminal-Window-in-Ubuntu).
+
+Enter the following command into the terminal and press the `ENTER` key:
+
+```bash
+docker container run --rm -it --name "btp-setup-automator" "ghcr.io/sap-samples/btp-setup-automator:main"
+```
+
+You'll notice that the prompt in your terminal has changed, because you are now working inside the docker container, that you just started.
+Now run the main script `btpsa` with the following command:
+
+```bash
+./btpsa -parameterfile 'usecases/other/dsag/2022-technologydays/parameters.json' \
+    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
+    -region        '<region for your subaccount e.g. us10>' \
+    -myemail       '<your email address>'
+```
+
+The tool starts to execute and the only thing you need to type-in is your password for your SAP BTP account. The btp-setup-automator script will now prepare your SAP BTP account to cover the discovery center mission.
+
+> ⚠ NOTE: In case you don't have the rights to create your own sub account, you should add the sub account id as a parameter to the command. That should look like this:
+
+```bash
+./btpsa -parameterfile 'usecases/other/dsag/2022-technologydays/parameters.json' \
+    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
+    -subaccountid  '<your sub account id as shown in the SAP BTP cockpit>'
+    -region        'region for your subaccount e.g. us10>' \
+    -myemail       'your email address>'
+```
+
+This command will create:
+
+- the Event Mesh service
+- the Event Mesh application (for UI access)
+- the service keys to access the Event Mesh service

--- a/usecases/other/dsag/2022-technologydays/parameters.json
+++ b/usecases/other/dsag/2022-technologydays/parameters.json
@@ -1,0 +1,5 @@
+{
+  "usecasefile": "usecases/other/dsag/2022-technologydays/usecase.json",
+  "region": "us10",
+  "subaccountname": "dsagtt2022"
+}

--- a/usecases/other/dsag/2022-technologydays/usecase.json
+++ b/usecases/other/dsag/2022-technologydays/usecase.json
@@ -1,0 +1,65 @@
+{
+  "aboutThisUseCase": {
+    "name": "Create a SAP Event Mesh setup as required for the DSAG Technology Days 2022 Kyma Hands-On",
+    "description": "This use case provides the configuration set up of the SAP Event Mesh i. e. the SAP Event Mesh service, the SAP Event Mesh application and the service keys.",
+    "author": "christian.lechner@sap.com",
+    "testStatus": "tested successfully",
+    "usageStatus": "READY TO BE USED",
+    "relatedLinks": [
+      "https://github.com/SAP-samples/kyma-runtime-extension-samples/tree/main/dsagtt22"
+    ]
+  },
+  "services": [
+    {
+      "name": "enterprise-messaging",
+      "plan": "default",
+      "category": "SERVICE",
+      "instancename": "dsagtt22-btpsa",
+      "parameters": {
+        "emname": "dsagtt22-btpsa",
+        "namespace": "default/dsagtt22btpsa.kyma/eventing.demo",
+        "version": "1.1.0",
+        "resources": {
+          "units": "10"
+        },
+        "options": {
+          "management": true,
+          "messagingrest": true,
+          "messaging": true
+        },
+        "rules": {
+          "queueRules": {
+            "publishFilter": [
+              "${namespace}/*"
+            ],
+            "subscribeFilter": [
+              "${namespace}/*"
+            ]
+          },
+          "topicRules": {
+            "publishFilter": [
+              "${namespace}/*"
+            ],
+            "subscribeFilter": [
+              "${namespace}/*"
+            ]
+          }
+        }
+      },
+      "createServiceKeys": [
+        "dsagtt22btpsaeventmeshsk"
+      ]
+    },
+    {
+      "name": "enterprise-messaging-hub",
+      "plan": "standard",
+      "category": "APPLICATION",
+      "requiredrolecollections": [
+        "Enterprise Messaging Administrator",
+        "Enterprise Messaging Developer",
+        "Enterprise Messaging Subscription Administrator"
+      ]
+    }
+  ],
+  "admins": []
+}


### PR DESCRIPTION
**Usecase**:

Developing a use case for a workshop where participants will deploy applications in a subaccount. I want to be able to prune the subaccount after the workshop. The participant might have followed all exercises, or not, so I don't know the final state of the subaccount.

**Current behaviour**:

If there is a command in the prune section that fails (trying to delete an app that is not in the subaccount), the script will halt and the use case won't be completed. The subscriptions and service instances won't be removed, and the subaccount won't be deleted.

**Behaviour with the change**:

Adding an (optional) parameter in the command (`"exitIfError": false`) will keep the script running even if that specific command fails. If the parameter is not added, the default value `"exitIfError": true` will ensure the script behaves as usual.

Thanks,
Pedro