### PR TITLE
exitIfError added as a global parameter

### DIFF
--- a/docs/PARAMETERS-BTPSA.md
+++ b/docs/PARAMETERS-BTPSA.md
@@ -22,6 +22,7 @@ These are the available commands:
 | createServiceKeys | list of service keys to be created for a service  | list | False | None |
 | requiredServices | list of service keys to be created for a service  | list | False | None |
 | requiredrolecollections | list of role collections to be created for a service | list | False | None |
+| exitIfError | Stop `btp-setup-automator` if any command (before, after and prune) fail | bool | False | True |
 
 You can get an overview of those commands as well, by simply typing the following command in your command line terminal:
 

--- a/docs/SAMPLECONFIG.md
+++ b/docs/SAMPLECONFIG.md
@@ -113,6 +113,16 @@ You specify the behavior via two parameters:
 
 > ⚠ NOTE: Be aware that all setups done via commands must be reversed. This must be done via commands provided in the `executeToPruneUseCase` section.  
 
+### Exit if error - Handle with Care
+
+`btp-setup-automator` supports executing custom commands at three stages:
+
+- `executeBeforeAccountSetup`
+- `executeAfterAccountSetup`
+- `executeToPruneUseCase`
+
+In the case of a command failing in any of the sections, the default behavior of `btp-setup-automator` is to stop the use case execution. In some cases, you might want to continue the execution even if some of the commands fail. You can control this by setting the `exitIfError` parameter to `false` in the `parameters.json` file.
+
 ### Parameter Examples
 
 You find several examples for parameter files in the folder `integrationtests/parameterfiles`.

--- a/libs/json/paramBtpSetupAutomator.json
+++ b/libs/json/paramBtpSetupAutomator.json
@@ -189,5 +189,11 @@
         "type": "str",
         "help": "list of environment variables on OS level to be used within commands defined in the `executeBeforeAccountSetup` and `executeAfterAccountSetup`.",
         "default": null
+    },
+    {
+        "argument": "exitIfError",
+        "type": "bool",
+        "help": "if set to True: btpsa will stop if any command (from before, after and prune) fail. if set to False, btpsa will continue even if commands (from before, after and prune) fail",
+        "default": true
     }
 ]

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -181,6 +181,9 @@ def executeCommandsFromUsecaseFile(btpUsecase, message, jsonSection):
         commands = usecaseDefinition[jsonSection]
         log.header(message)
 
+        # Set exitIfError from parameters (default is True)
+        exitIfError = btpUsecase.exitIfError
+
         for command in commands:
             # if "parameters" in command:
             #     parameters = command["parameters"]
@@ -190,7 +193,7 @@ def executeCommandsFromUsecaseFile(btpUsecase, message, jsonSection):
                 thisCommand = command["command"]
                 log.header("COMMAND EXECUTION: " + message)
 
-                p = runShellCommandFlex(btpUsecase, thisCommand, "INFO", "Executing the following commands:\n" + thisCommand + "\n", True, True)
+                p = runShellCommandFlex(btpUsecase, thisCommand, "INFO", "Executing the following commands:\n" + thisCommand + "\n", exitIfError, True)
                 if p is not None and p.stdout is not None:
                     result = p.stdout.decode()
                     log.success(result)

--- a/usecases/other/exitIfError/test-exitIfError-usecase.json
+++ b/usecases/other/exitIfError/test-exitIfError-usecase.json
@@ -1,0 +1,30 @@
+{
+    "aboutThisUseCase": {
+      "name": "Usecase with failing commands",
+      "description": "Use this use case to test the global flag exitIfError. This is a minimal use case with failing commands in the before, after, and prune sections",
+      "author": "pedro.iranzo.egea@sap.com",
+      "testStatus": "tested successfully",
+      "usageStatus": "NOT TO BE USED IN PRODUCTION"
+    },
+    "services": [],
+    "admins": ["pedro.iranzo.egea@sap.com"],
+    "executeBeforeAccountSetup": [
+        {
+            "description": "Failing command",
+            "command": "exit 1"
+        }
+    ],
+    "executeAfterAccountSetup": [
+        {
+            "description": "Failing command",
+            "command": "exit 1"
+        }
+    ],
+    "executeToPruneUseCase": [
+        {
+            "description": "Failing command",
+            "command": "exit 1"
+        }
+    ]
+  }
+  


### PR DESCRIPTION
Hello,

I implemented a new global parameter to control if `btp-setup-automator` should stop the execution of the use case in case of a command failing, or if it should ignore it and continue the execution.
This parameter affects the commands from `executeBeforeAccountSetup`, `executeAfterAccountSetup`, `executeToPruneUseCase`.

**Usecase**:

Developing a use case for a workshop where participants will deploy applications in a subaccount. I want to be able to prune the subaccount after the workshop. The participant might have followed all exercises, or not, so I don't know the final state of the subaccount. I need to be able to prune the subaccount regardless of the content in the subaccount.

**Current behaviour**:

If there is a command in the prune section that fails (trying to delete an app that is not in the subaccount), `btp-setup-automator` will halt and the use case won't be completed. The subscriptions and service instances won't be removed, and the subaccount won't be deleted.

**Behaviour with the change**:

If I set `exitIfError` parameter to `false` in the `parameters.json` file, `btp-setup-automator` will continue running even if one specific command fails. 

This parameter is optional, and the default value is `true`.

**Summary of changes**:

- Added logic in `helperCommandExecution.py`
- Added global parameter in `paramBtpSetupAutomator.json`
- Added documentation in `PARAMETERS-BTPSA.md` and `SAMPLECONFIG.md`
- Added sample use case under `other/` with failing commands to test

Thanks,
Pedro