### PR TITLE
improve ability to copy-and-paste commands

### DIFF
--- a/usecases/released/discoverycenter/3239-customui/README.md
+++ b/usecases/released/discoverycenter/3239-customui/README.md
@@ -28,9 +28,9 @@ Now run the main script `btpsa` with the following command:
 
 ```bash
 ./btpsa -parameterfile 'usecases/released/discoverycenter/3239-customui/parameters.json' \
-    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
-    -region        '<region for your subaccount e.g. us10>' \
-    -myemail       '<your email address>'
+    -globalaccount 'your_global_account_subdomain_as_shown_in_the_SAP_BTP_cockpit'  \
+    -region        'region_for_your_subaccount_eg_us10' \
+    -myemail       'your_email_address'
 ```
 
 The tool starts to execute and the only thing you need to type-in is your password for your SAP BTP account. The btp-setup-automator script will now prepare your SAP BTP account to cover the discovery center mission.
@@ -39,10 +39,10 @@ The tool starts to execute and the only thing you need to type-in is your passwo
 
 ```bash
 ./btpsa -parameterfile 'usecases/other/discoverycenter/3774-taskcenter/parameters.json' \
-    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
-    -subaccountid  '<your sub account id as shown in the SAP BTP cockpit>'
-    -region        'region for your subaccount e.g. us10>' \
-    -myemail       'your email address>'
+    -globalaccount 'your_global_account_subdomain_as_shown_in_the_SAP_BTP_cockpit'  \
+    -subaccountid  'your_sub_account_id_as_shown_in_the_SAP_BTP_cockpit'
+    -region        'region_for_your_subaccount_eg_us10' \
+    -myemail       'your_email_address'
 ```
 
 If you want to understand other possible parameters, give the following command:
@@ -55,9 +55,9 @@ If you want to understand other possible parameters, give the following command:
 
 ```bash
 ./btpsa -parameterfile 'usecases/other/discoverycenter/3774-taskcenter/parameters.json' \
-    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
-    -subaccountid  '<your sub account id as shown in the SAP BTP cockpit>'
-    -region        'region for your subaccount e.g. us10>' \
-    -myemail       'your email address>' \
+    -globalaccount 'your_global_account_subdomain_as_shown_in_the_SAP_BTP_cockpit'  \
+    -subaccountid  'your_sub_account_id_as_shown_in_the_SAP_BTP_cockpit'
+    -region        'region_for_your_subaccount_eg_us10' \
+    -myemail       'your_email_address' \
     -loginmethod   sso
 ```

--- a/usecases/released/discoverycenter/3774-taskcenter/README.md
+++ b/usecases/released/discoverycenter/3774-taskcenter/README.md
@@ -28,9 +28,9 @@ Now run the main script `btpsa` with the following command:
 
 ```bash
 ./btpsa -parameterfile 'usecases/other/discoverycenter/3774-taskcenter/parameters.json' \
-    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
-    -region        '<region for your subaccount e.g. us10>' \
-    -myemail       '<your email address>'
+    -globalaccount 'your_global_account_subdomain_as_shown_in_the_SAP_BTP_cockpit'  \
+    -region        'region_for_your_subaccount_eg_us10' \
+    -myemail       'your_email_address'
 ```
 
 The tool starts to execute and the only thing you need to type-in is your password for your SAP BTP account. The btp-setup-automator script will now prepare your SAP BTP account to cover the discovery center mission.
@@ -39,8 +39,9 @@ The tool starts to execute and the only thing you need to type-in is your passwo
 
 ```bash
 ./btpsa -parameterfile 'usecases/other/discoverycenter/3774-taskcenter/parameters.json' \
-    -globalaccount '<your global account subdomain as shown in the SAP BTP cockpit>'  \
-    -subaccountid  '<your sub account id as shown in the SAP BTP cockpit>'
-    -region        'region for your subaccount e.g. us10>' \
-    -myemail       'your email address>'
+    -globalaccount 'your_global_account_subdomain_as_shown_in_the_SAP_BTP_cockpit'  \
+    -subaccountid  'your_sub_account_id_as_shown_in_the_SAP_BTP_cockpit'
+    -region        'region_for_your_subaccount_eg_us10' \
+    -myemail       'your_email_address'
+
 ```


### PR DESCRIPTION
Changed the commands for the discovery center missions, so that it's easier to copy-and-paste them into the terminal and then overwrite the explanations with a simple double-click.