### PR TITLE
Fix for defaulting of AccountMetadata OrgID

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -243,8 +243,7 @@ class BTPUSECASE:
         subaccountid = accountMetadata["subaccountid"]
 
         orgid = self.orgid
-        self.accountMetadata = addKeyValuePair(accountMetadata, "orgid", orgid)
-
+        
         if self.orgid is not None and self.orgid != "":
             self.accountMetadata = addKeyValuePair(accountMetadata, "orgid", self.orgid)
 


### PR DESCRIPTION
This PR provides a fix for the defaulted orgID that does not consider if empty/none or if filled with a value

It solves issue #73 