### PR TITLE
Enhancement of RUN files to run container from container registry 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,26 @@ The tool starts to execute and the only thing you need to type-in is your passwo
 > ```bash
 > docker container run --rm -it -d --name "btp-setup-automator" "ghcr.io/sap-samples/btp-setup-automator:main"
 > ```
->
+
+You can also use the provided `run` files to pull the image from the registry and start the container via one command. To do so execute the following command:
+
+- bash (macOS/Linux)
+
+  ```bash
+  ./run RunFromRegistry
+  ```
+
+- Command Prompt (Windows):
+
+  ```cmd
+  .\run.bat RunFromRegistry
+  ```
+
+- PowerShell Core (Cross Platform):
+
+  ```powershell
+  .\run.ps1 -RunFromRegistry $True 
+  ```
 
 ### Option 2: Start Docker Container With Self-Built Image
 

--- a/run
+++ b/run
@@ -8,8 +8,8 @@ docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
 docker image     rmi -f "btp-setup-automator"
 
-if ($1 != "--no-build")
-then
+
+if [ "$1" != "RunFromRegistry" ]; then
     
     echo -e "${GREEN}Building the container image ...${NOCOLOR}"
     docker image build -t btp-setup-automator:latest -f "config/containerdefinitions/btp-setup-automator/Dockerfile"  .

--- a/run
+++ b/run
@@ -8,8 +8,23 @@ docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
 docker image     rmi -f "btp-setup-automator"
 
-echo -e "${GREEN}Building the container image ...${NOCOLOR}"
-docker image build -t btp-setup-automator:latest -f "config/containerdefinitions/btp-setup-automator/Dockerfile"  .
+if ($1 != "--no-build")
+then
+    
+    echo -e "${GREEN}Building the container image ...${NOCOLOR}"
+    docker image build -t btp-setup-automator:latest -f "config/containerdefinitions/btp-setup-automator/Dockerfile"  .
 
-echo -e "${GREEN}Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode${NOCOLOR}"
-docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --platform linux/amd64 --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
+    echo -e "${GREEN}Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode${NOCOLOR}"
+    docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --platform linux/amd64 --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
+
+else
+
+    echo -e "${GREEN}Pulling container image from registry ...${NOCOLOR}"
+    docker pull ghcr.io/sap-samples/btp-setup-automator:main
+
+    echo -e "${GREEN}Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode${NOCOLOR}"
+    docker container run --rm  -it -d --name "btp-setup-automator" ghcr.io/sap-samples/btp-setup-automator:main 
+
+fi
+
+

--- a/run.bat
+++ b/run.bat
@@ -8,7 +8,7 @@ docker container rm  -f "btp-setup-automator"
 docker image     rmi -f "btp-setup-automator"
 
 
-if "%1" != "RunFromRegistry" (
+if not "%1" == "RunFromRegistry" (
   
   echo %ESC%[32mBuilding the container image ...%ESC%[0m
   docker image     build -t btp-setup-automator:latest -f .\config\containerdefinitions\btp-setup-automator\Dockerfile .

--- a/run.bat
+++ b/run.bat
@@ -7,11 +7,24 @@ docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
 docker image     rmi -f "btp-setup-automator"
 
-echo %ESC%[32mBuilding the container image ...%ESC%[0m
-docker image     build -t btp-setup-automator:latest -f .\config\containerdefinitions\btp-setup-automator\Dockerfile .
 
-echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VSCode%ESC%[0m
-docker container run --platform linux/amd64 -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name btp-setup-automator btp-setup-automator
+if "%1" != "RunFromRegistry" (
+  
+  echo %ESC%[32mBuilding the container image ...%ESC%[0m
+  docker image     build -t btp-setup-automator:latest -f .\config\containerdefinitions\btp-setup-automator\Dockerfile .
+
+  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VSCode%ESC%[0m
+  docker container run --platform linux/amd64 -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name btp-setup-automator btp-setup-automator
+
+) else (
+
+  echo %ESC%[32mPulling container image from registry ...%ESC%[0m
+  docker pull ghcr.io/sap-samples/btp-setup-automator:main
+
+  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VSCode%ESC%[0m
+  docker container run --rm  -it -d --name btp-setup-automator ghcr.io/sap-samples/btp-setup-automator:main
+
+)
 
 :setESC
 for /F "tokens=1,2 delims=#" %%a in ('"prompt #$H#$E# & echo on & for %%b in (1) do rem"') do (

--- a/run.ps1
+++ b/run.ps1
@@ -1,12 +1,27 @@
 #!/usr/bin/pwsh
+Param(
+    [Parameter(Mandatory=$False)]
+    [bool]$RunFromRegistry = $False
+)
 
 Write-Host "Cleaning up containers and images (if existing)" -ForegroundColor green
 docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
 docker image     rmi -f "btp-setup-automator"
 
-Write-Host "Building the container image ..." -ForegroundColor green
-docker image build -t btp-setup-automator:latest -f "config/containerdefinitions/btp-setup-automator/Dockerfile"  .
+if ( $RunFromRegistry -eq $False )
+{
+    Write-Host "Building the container image ..." -ForegroundColor green
+    docker image build -t btp-setup-automator:latest -f "config/containerdefinitions/btp-setup-automator/Dockerfile"  .
 
-Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode" -ForegroundColor green
-docker container run --platform linux/amd64 -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
+    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode" -ForegroundColor green
+    docker container run --platform linux/amd64 -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
+}
+else
+{
+    Write-Host "Pulling container image from registry ..." -ForegroundColor green
+    docker pull ghcr.io/sap-samples/btp-setup-automator:main 
+
+    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode" -ForegroundColor green
+    docker container run --rm  -it -d --name "btp-setup-automator" ghcr.io/sap-samples/btp-setup-automator:main 
+}


### PR DESCRIPTION
This PR contains changes in the `run*` files to enable the execution of the btp-setup-automator using the latest image from the container registry. The parameter is optional and the existing behavior works without any changes needed. 

The enhancement of the documentation is also part of this PR.