### PR TITLE
Build Images for different platforms

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,41 +1,50 @@
 name: Build and Push Docker Image
 
-on: 
+on:
   release:
     types: [published]
   workflow_dispatch:
-    
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build_and_push:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build Docker image
         uses: docker/build-push-action@v2.10.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           file: ./config/containerdefinitions/btp-setup-automator/Dockerfile
-          build-args: | 
+          build-args: |
             BTPSA_VERSION_GIT_ARG=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}          
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v2.10.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           file: ./config/containerdefinitions/btp-setup-automator/Dockerfile
           build-args: |
             BTPSA_VERSION_GIT_ARG=${{ github.sha }}


### PR DESCRIPTION
This PR contains the changes necessary to build and push the container images for the two platforms 
- `linux/amd64`
- `linux/arm64`

The adjustments in `docker-build-and-push.yaml` are:
- Setup of QEMU
- Setup of Docker Buildx
- Enhancement of the build&push step via the parameter `platforms: linux/amd64,linux/arm64`

As the build is now slowed down, the quality check action `build-quality-check.yaml` was not enhanced to get a quick feedback for PRs.
 