### PR TITLE
Fix cfenv helper: error when non-cf environment exists

### DIFF
--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -33,7 +33,7 @@ def checkIfCFEnvironmentAlreadyExists(btpUsecase):
 
     # If the for loop didn't return any value, the orgid wasn't found
     for instance in result["environmentInstances"]:
-        if instance["subaccountGUID"] == btpUsecase.subaccountid:
+        if instance["subaccountGUID"] == btpUsecase.subaccountid and instance["environmentType"] == "cloudfoundry":
             labels = convertStringToJson(instance["labels"])
             org = labels["Org Name:"]
             return instance["platformId"], org


### PR DESCRIPTION
The refactoring in commit [a4059689e9778c94309081c82d426b5f8d4d795e](https://github.com/SAP-samples/btp-setup-automator/commit/a4059689e9778c94309081c82d426b5f8d4d795e). Leads to an error if a non-CF environment is already existing in the subaccount.

The loop is executed as e.g. the existing Kyma environment is returned. However, the assignment of the org variable in line 38  fails as the array for a Kyma environment does not contain an entry with id "Org Name".

This PR fixes the bug by adding an additional check in the loop.