### PR TITLE
Feature Request 58 - global defaulting of cluster region

### DIFF
--- a/libs/json/templates/BTPSA-PARAMETERS.json
+++ b/libs/json/templates/BTPSA-PARAMETERS.json
@@ -45,6 +45,11 @@
             "default": "us10",
             "enum": {{ enumDatacenterList }}
         },
+        "clusterregion": {
+            "type": "string",
+            "description": "region for the SAP BTP Kyma runtime cluster. This parameter is used as default for Kyma cluster creation. Override via usecase.json possible",
+            "title": "region for SAP BTP Kyma runtime cluster"
+        },
         "subaccountid": {
             "type": "string",
             "description": "id of your sub account that should be used",
@@ -273,5 +278,19 @@
             "title": "update the automatically created documentation",
             "default": false
         }
-    }
+    },
+    "allOf": [
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["us10", "eu10", "br10", "jp10", "ca10", "ap12", "ap10", "ap11"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["eu-central-1", "eu-west-2", "ca-central-1", "sa-east-1", "us-east-1", "us-west-1","ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"] }}}
+        },
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["us30"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["asia-south1", "us-central1", "europe-west3"] }}}
+        },
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["ap21", "us20", "jp20", "us21", "eu20"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["centralus", "eastus", "westus2", "northeurope", "uksouth", "japaneast", "southeastasia", "westeurope"] }}}
+        }
+    ]
 }

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -341,6 +341,28 @@ class BTPUSECASE:
                 elif environment.name == "kymaruntime":
                     kymaClusterName = environment.parameters["name"]
 
+                    # Set Cluster region: the cluster region can be globally defined via the parameters file
+                    # or for each environment in the usecase file. Therefore we need to consolidate the setting here
+                    # In addition the difference between TRIAL and Prod must be considered => Prod has a cluster region, TRIAL has not
+                    clusterregion = None
+
+                    if environment.plan == "trial":
+                        clusterregion = self.region
+                    else:
+                        if "region" in environment.parameters:
+                            if environment.parameters["region"] != "":
+                                clusterregion = environment.parameters["region"]
+                            else:
+                                clusterregion = self.clusterregion
+                                environment.parameters["region"] = clusterregion
+                        else:
+                            clusterregion = self.clusterregion
+                            environment.parameters["region"] = clusterregion
+
+                    if clusterregion is None or clusterregion == "":
+                        log.error("A value for the > CLUSTER REGION < was not provided but is necessary for the setup of the BTP environment >" + environment.name + "<.")
+                        sys.exit(os.EX_DATAERR)
+
                     # Check if environment alraedy exists
                     message = "Check if Kyma cluster called " + kymaClusterName + "already exists"
 
@@ -359,18 +381,11 @@ class BTPUSECASE:
                     envName = environment.name
                     # Fix environment name for instance creation
                     btpEnvironment = "kyma"
-                    clusterregion = None
                     parameters = None
-
-                    parameters = dictToString(environment.parameters)
 
                     envLandscape = selectEnvironmentLandscape(self, environment)
 
-                    # Difference between TRIAL and Prod => Prod has a cluster region, TRIAL has not
-                    if environment.plan == "trial":
-                        clusterregion = self.region
-                    else:
-                        clusterregion = environment.parameters["region"]
+                    parameters = dictToString(environment.parameters)
 
                     if envLandscape is not None:
                         command = "btp --format json create accounts/environment-instance --subaccount '" + subaccountid + "' --environment '" + btpEnvironment + \

--- a/schemas/btpsa-parameters.json
+++ b/schemas/btpsa-parameters.json
@@ -82,6 +82,11 @@
   "us4"
 ]
         },
+        "clusterregion": {
+            "type": "string",
+            "description": "region for the SAP BTP Kyma runtime cluster. This parameter is used as default for Kyma cluster creation. Override via usecase.json possible",
+            "title": "region for SAP BTP Kyma runtime cluster"
+        },
         "subaccountid": {
             "type": "string",
             "description": "id of your sub account that should be used",
@@ -310,5 +315,19 @@
             "title": "update the automatically created documentation",
             "default": false
         }
-    }
+    },
+    "allOf": [
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["us10", "eu10", "br10", "jp10", "ca10", "ap12", "ap10", "ap11"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["eu-central-1", "eu-west-2", "ca-central-1", "sa-east-1", "us-east-1", "us-west-1","ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"] }}}
+        },
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["us30"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["asia-south1", "us-central1", "europe-west3"] }}}
+        },
+        {
+            "if": {"properties": { "region": { "anyOf": [ {"enum": ["ap21", "us20", "jp20", "us21", "eu20"]}] }}},
+            "then": { "properties": {"clusterregion": {"enum": ["centralus", "eastus", "westus2", "northeurope", "uksouth", "japaneast", "southeastasia", "westeurope"] }}}
+        }
+    ]
 }


### PR DESCRIPTION
This PR contains the necessary changes requested in #58 . 

The code of the BTP Setup Automator is adjusted and you have the following options to define a cluster region:

- In the `parameters` files as `clusterregion`
- In the `usecase` file  as "region" in the parameters section for the Kyma environment

If the value is set in the  `usecase` file, this parameter is used when creating a Kyma cluster (which also ensures backwards compatibility). If the value is set in the `parameters` file and no or an empty value is set in the `usecase` file, the one in the `parameters` file is taken.

In case no cluster region is provided the processing is aborted

The JSON schema definitions are also extended and a base check for the cluster regions based on the region is implemented for the `parameters` file. The values are hard coded due to limitations of the BTP CLI to determine the valid cluster region. 