### PR TITLE
Restructuring of Service Creation

### DIFF
--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -20,3 +20,4 @@ requests==2.27.1
 six==1.16.0
 urllib3==1.26.9
 wcwidth==0.2.5
+pyyaml==6.0

--- a/libs/json/templates/K8s-SERVICE-BINDING.json
+++ b/libs/json/templates/K8s-SERVICE-BINDING.json
@@ -1,0 +1,13 @@
+{
+    "apiVersion": "services.cloud.sap.com/v1",
+    "kind": "ServiceBinding",
+    "metadata": {
+        "name": "my-service-binding"
+    },
+    "spec": {
+        "serviceInstanceName": "my-service-instance",
+        "externalName": "my-service-instance-external",
+        "secretName": "mySecret",
+        "parameters": {}
+    }
+}

--- a/libs/json/templates/K8s-SERVICE-INSTANCE.json
+++ b/libs/json/templates/K8s-SERVICE-INSTANCE.json
@@ -1,0 +1,13 @@
+{
+    "apiVersion": "services.cloud.sap.com/v1",
+    "kind": "ServiceInstance",
+    "metadata": {
+        "name": "my-service-instance"
+    },
+    "spec": {
+        "serviceOfferingName": "sample-service",
+        "servicePlanName": "sample-plan",
+        "externalName": "my-service-instance-external",
+        "parameters": {}
+    }
+}

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -2,7 +2,8 @@ import libs.python.helperArgParser as helperArgParser
 from libs.python.helperJson import addKeyValuePair, dictToString, convertStringToJson, getJsonFromFile
 from libs.python.helperBtpTrust import delete_cf_service_key, runTrustFlow, get_cf_service_key
 from libs.python.helperCommandExecution import executeCommandsFromUsecaseFile, runShellCommand, runCommandAndGetJsonResult, runShellCommandFlex, login_btp, login_cf
-from libs.python.helperEnvCF import checkIfAllServiceInstancesCreated, checkIfCFEnvironmentAlreadyExists, checkIfCFSpaceAlreadyExists, try_until_cf_space_done, initiateCreationOfServiceInstances, get_cf_service_deletion_status
+from libs.python.helperEnvCF import checkIfCFEnvironmentAlreadyExists, checkIfCFSpaceAlreadyExists, try_until_cf_space_done, get_cf_service_deletion_status
+from libs.python.helperServiceCreation import initiateCreationOfServiceInstances, checkIfAllServiceInstancesCreated
 from libs.python.helperGeneric import buildUrltoSubaccount, getNamingPatternForServiceSuffix, createSubaccountName, createSubdomainID, createOrgName, getTimingsForStatusRequest, save_collected_metadata
 from libs.python.helperFileAccess import writeKubeConfigFileToDefaultDir
 from libs.python.helperEnvKyma import extractKymaDashboardUrlFromEnvironmentDataEntry, getKymaEnvironmentInfoByClusterName, getKymaEnvironmentStatusFromEnvironmentDataEntry, extractKymaKubeConfigUrlFromEnvironmentDataEntry, getKymaEnvironmentIdByClusterName
@@ -121,8 +122,6 @@ class BTPUSECASE:
         assignUsersToGlobalAndSubaccount(self)
         assignUsersToEnvironments(self)
 
-        # set_all_cf_space_roles(self)
-        # set_all_cf_org_roles(self)
         None
 
     def prune_subaccount(self, subaccountid):
@@ -606,7 +605,6 @@ def check_if_account_can_cover_use_case_for_serviceType(btpUsecase: BTPUSECASE, 
             if (accountServiceName == usecaseServiceName):
                 for accountServicePlan in accountService["servicePlans"]:
                     accountServicePlanName = accountServicePlan["name"]
-#                   accountServicePlanCategory = accountServicePlan["category"]
                     if fallbackServicePlan is not None and accountServicePlanName == fallbackServicePlan:
                         for accountServicePlanDataCenter in accountServicePlan["dataCenters"]:
                             accountServicePlanRegion = accountServicePlanDataCenter["region"]
@@ -904,37 +902,6 @@ def checkIfAllSubscriptionsAreAvailable(btpUsecase: BTPUSECASE):
     return allSubscriptionsAvailable
 
 
-# def checkIfAllSubscriptionsAreAvailable(btpUsecase: BTPUSECASE):
-#     command = "btp --format json list accounts/subscription --subaccount '" + btpUsecase.subaccountid + "'"
-#     resultCommand = runCommandAndGetJsonResult(btpUsecase, command, "INFO", "check status of app subscriptions")
-
-#     allSubscriptionsAvailable = True
-#     for thisJson in resultCommand["applications"]:
-#         name = thisJson["appName"]
-#         plan = thisJson["planName"]
-#         status = thisJson["state"]
-#         tenantId = thisJson["tenantId"]
-#         for app in btpUsecase.definedAppSubscriptions:
-#             if app.name == name and app.plan == plan and app.successInfoShown is False:
-#                 if status == "SUBSCRIBE_FAILED":
-#                     log.error("BTP account reported that subscription on >" + app.name + "< has failed.")
-#                     sys.exit(os.EX_DATAERR)
-
-#                 if status != "SUBSCRIBED":
-#                     allSubscriptionsAvailable = False
-#                     app.status = status
-#                     app.successInfoShown = False
-#                     app.statusResponse = thisJson
-#                 else:
-#                     log.success("subscription to app >" + app.name + "< (plan " + app.plan + ") is now available")
-#                     app.tenantId = tenantId
-#                     app.successInfoShown = True
-#                     app.statusResponse = thisJson
-#                     app.status = "SUBSCRIBED"
-
-#     return allSubscriptionsAvailable
-
-
 def determineTimeToFetchStatusUpdates(btpUsecase: BTPUSECASE):
     maxTiming = int(btpUsecase.repeatstatusrequest)
 
@@ -1085,7 +1052,6 @@ def pruneUseCaseAssets(btpUsecase: BTPUSECASE):
 
     if "createdServiceInstances" in accountMetadata and len(accountMetadata["createdServiceInstances"]) > 0:
         log.info("Delete service instances")
-        # login_cf(btpUsecase)
         # Initiate deletion of service instances
         for environment in btpUsecase.definedEnvironments:
             if environment.name == "cloudfoundry":

--- a/libs/python/helperEnvBTP.py
+++ b/libs/python/helperEnvBTP.py
@@ -1,0 +1,10 @@
+def get_btp_service_status(btpUsecase, service):
+    return "status"
+
+
+def create_btp_service(btpUsecase, service):
+    return "service"
+
+
+def getStatusResponseFromCreatedBTPInstance(btpUsecase, instancename):
+    return "status"

--- a/libs/python/helperEnvKyma.py
+++ b/libs/python/helperEnvKyma.py
@@ -26,3 +26,15 @@ def getKymaEnvironmentIdByClusterName(environmentData, kymaClusterName):
         parametersFromEntry = convertStringToJson(entry["parameters"])
         if entry["environmentType"] == "kyma" and parametersFromEntry["name"] == kymaClusterName:
             return entry["id"]
+
+
+def get_kyma_service_status(btpUsecase, service):
+    return "status"
+
+
+def create_kyma_service(btpUsecase, service):
+    return "service"
+
+
+def getStatusResponseFromCreatedKymaInstance(btpUsecase, instancename):
+    return "status"

--- a/libs/python/helperEnvKyma.py
+++ b/libs/python/helperEnvKyma.py
@@ -1,4 +1,6 @@
 from libs.python.helperJson import convertStringToJson
+from libs.python.helperYaml import build_service_binding_yaml_from_parameters, store_yaml_to_disk
+from libs.python.helperCommandExecution import runShellCommand
 
 
 def getKymaEnvironmentInfoByClusterName(environmentData, kymaClusterName):
@@ -29,12 +31,36 @@ def getKymaEnvironmentIdByClusterName(environmentData, kymaClusterName):
 
 
 def get_kyma_service_status(btpUsecase, service):
-    return "status"
+    command = "kubectl get ServiceInstance " + service.instanceName + " -n " + btpUsecase.accountMetadata.get("k8snamespace") + " --kubeconfig " + btpUsecase.accountMetadata.get("kubeconfigpath") + " | jq .status.ready"
+
+    p = runShellCommand(btpUsecase, command, "INFO", None)
+
+    if p.stdout.decode() == "TRUE":
+        return "create succeeded"
+    else:
+        return "NotReady"
 
 
 def create_kyma_service(btpUsecase, service):
-    return "service"
+    serviceInstanceYaml = build_service_binding_yaml_from_parameters(service)
+
+    filepath = "k8s/service-instance/service-instance-" + btpUsecase.accountMetadata.get("subaccountid") + ".yaml"
+    store_yaml_to_disk(filepath, serviceInstanceYaml)
+
+    # Call kubectl to create the service
+    command = "kubectl apply -f " + filepath + " -n " + btpUsecase.accountMetadata.get("k8snamespace") + " --kubeconfig " + btpUsecase.accountMetadata.get("kubeconfigpath")
+    message = "Create instance >" + service.instanceName + "< for service >" + service.name + "< and plan >" + service.plan + "<" + "in namespace >" + btpUsecase.accountMetadata.get("k8snamespace") + "<"
+
+    runShellCommand(btpUsecase, command, "INFO", message)
+
+    return service
 
 
-def getStatusResponseFromCreatedKymaInstance(btpUsecase, instancename):
-    return "status"
+def getStatusResponseFromCreatedKymaInstance(btpUsecase, instanceName):
+    command = "kubectl get ServiceInstance " + instanceName + " -n " + btpUsecase.accountMetadata.get("k8snamespace") + " --kubeconfig " + btpUsecase.accountMetadata.get("kubeconfigpath") + " -o json"
+
+    p = runShellCommand(btpUsecase, command, "INFO", None)
+
+    jsonResult = convertStringToJson(p.stdout.decode())
+
+    return jsonResult

--- a/libs/python/helperServiceCreation.py
+++ b/libs/python/helperServiceCreation.py
@@ -130,7 +130,7 @@ def createServiceInstance(btpUsecase, service, targetEnvironment, serviceCategor
         service = create_kyma_service(btpUsecase, service)
     elif targetEnvironment == "other":
         service = create_btp_service(btpUsecase, service)   
-    return service   
+    return service  
 
 
 def getStatusResponseFromCreatedInstance(btpUsecase, instancename, targetEnvironment):

--- a/libs/python/helperServiceCreation.py
+++ b/libs/python/helperServiceCreation.py
@@ -1,0 +1,143 @@
+from libs.python.helperCommandExecution import runShellCommand, login_cf
+from libs.python.helperGeneric import getServiceByServiceName, createInstanceName, getTimingsForStatusRequest
+from libs.python.helperJson import convertCloudFoundryCommandOutputToJson
+from libs.python.helperEnvCF import get_cf_service_status, create_cf_service, create_cf_cup_service, getStatusResponseFromCreatedCFInstance
+from libs.python.helperEnvBTP import get_btp_service_status, create_btp_service, getStatusResponseFromCreatedBTPInstance
+from libs.python.helperEnvKyma import get_kyma_service_status, create_kyma_service, getStatusResponseFromCreatedKymaInstance
+import time
+import os
+import sys
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def checkIfAllServiceInstancesCreated(btpUsecase):
+    command = "cf services"
+    p = runShellCommand(btpUsecase, command, "INFO", None)
+    result = p.stdout.decode()
+    jsonResults = convertCloudFoundryCommandOutputToJson(result)
+
+    allServicesCreated = True
+    for thisJson in jsonResults:
+        name = thisJson.get("service")
+        if name is None:
+            name = thisJson.get("offering")
+
+        plan = thisJson.get("plan")
+        instancename = thisJson.get("name")
+        status = thisJson.get("last operation")
+        servicebroker = thisJson.get("broker")
+        for service in btpUsecase.definedServices:
+            if service.name == name and service.plan == plan and service.instancename == instancename and service.successInfoShown is False:
+                if status != "create succeeded" and status != "update succeeded":
+                    allServicesCreated = False
+                    service.status = "NOT READY"
+                    service.successInfoShown = False
+                else:
+                    log.success("Service instance for service >" + service.name + "< (plan " + service.plan + ") is now available")
+                    service.servicebroker = servicebroker
+                    service.successInfoShown = True
+                    service.status = "create succeeded"
+                    service.statusResponse = getStatusResponseFromCreatedInstance(btpUsecase, instancename)
+    return allServicesCreated
+
+
+def initiateCreationOfServiceInstances(btpUsecase):
+    createServiceInstances = btpUsecase.definedServices is not None and len(btpUsecase.definedServices) > 0
+
+    if createServiceInstances is True:
+        login_cf(btpUsecase)
+        log.header("Initiate creation of service instances")
+
+        # First add all instance names to the services
+        for service in btpUsecase.definedServices:
+            instancename = createInstanceName(btpUsecase, service)
+            service.instancename = instancename
+
+        # Check whether there are services with the same instance name
+        # If there are, it's not safe to create the service instances
+        for service in btpUsecase.definedServices:
+            instanceName = service.instancename
+            counter = 0
+            for thisService in btpUsecase.definedServices:
+                thisInstanceName = thisService.instancename
+                if thisInstanceName == instanceName:
+                    counter += 1
+            if counter > 1:
+                log.error("there is more than one service with the instance name >" + instanceName + "<. Please fix that before moving on.")
+                sys.exit(os.EX_DATAERR)
+
+        serviceInstancesToBeCreated = []
+        # Restrict the creation of service instances to those
+        # that have been set to entitleOnly to False (default)
+        for service in btpUsecase.definedServices:
+            if service.entitleonly is False:
+                serviceInstancesToBeCreated.append(service)
+
+        # Now create all the service instances
+        for service in serviceInstancesToBeCreated:
+            serviceName = service.name
+            # Quickly initiate the creation of all service instances (without waiting until they are all created)
+            if service.requiredServices is not None and len(service.requiredServices) > 0:
+                for requiredService in service.requiredServices:
+                    thisService = getServiceByServiceName(btpUsecase, requiredService)
+                    if thisService is not None:
+                        current_time = 0
+                        search_every_x_seconds, usecaseTimeout = getTimingsForStatusRequest(btpUsecase, thisService)
+                        # Wait until thisService has been created and is available
+                        while usecaseTimeout > current_time:
+                            status = get_service_status(btpUsecase, thisService, service.targetenvironment)
+                            if (status == "create succeeded" or status == "update succeeded"):
+                                log.success("service >" + requiredService + "< now ready as pre-requisite for service >" + serviceName + "<")
+                                if service.category == "SERVICE" or service.category == "ELASTIC_SERVICE":
+                                    service = createServiceInstance(btpUsecase, service, service.targetenvironment, service.category)
+                                else:
+                                    log.info("this service >" + serviceName + "< is not of type SERVICE or ELASTIC_SERVICE and a service instance won't be created")
+                                    service.status = "create succeeded"
+                                break
+                            else:
+                                log.check("waiting for service >" + requiredService + "< (status >" + status +
+                                          "<) to finish as pre-requisite for service >" + serviceName + "< (trying again in " + str(search_every_x_seconds) + "s)")
+
+                            time.sleep(search_every_x_seconds)
+                            current_time += search_every_x_seconds
+                    else:
+                        log.error("did not find the defined required service >" + requiredService +
+                                  "<, which is a pre-requisite for the service >" + serviceName + "<. Please check your configuration file!")
+            else:
+                service = createServiceInstance(btpUsecase, service, service.targetenvironment, service.category)
+
+
+def get_service_status(btpUsecase, service, targetEnvironment):
+    if targetEnvironment == "cloudfoundry":
+        [servicebroker, status] = get_cf_service_status(btpUsecase, service)
+    elif targetEnvironment == "kymaruntime":
+        status = get_kyma_service_status(btpUsecase, service)
+    elif targetEnvironment == "other":
+        status = get_btp_service_status(btpUsecase, service)
+
+    return status
+
+
+def createServiceInstance(btpUsecase, service, targetEnvironment, serviceCategory):
+    if targetEnvironment == "cloudfoundry":
+        if serviceCategory == "SERVICE" or service.category == "ELASTIC_SERVICE":
+            service = create_cf_service(btpUsecase, service)
+        elif serviceCategory == "CF_CUP_SERVICE":
+            service = create_cf_cup_service(btpUsecase, service)
+    elif targetEnvironment == "kymaruntime":
+        service = create_kyma_service(btpUsecase, service)
+    elif targetEnvironment == "other":
+        service = create_btp_service(btpUsecase, service)   
+    return service   
+
+
+def getStatusResponseFromCreatedInstance(btpUsecase, instancename, targetEnvironment):
+    if targetEnvironment == "cloudfoundry":
+        statusResponse = getStatusResponseFromCreatedCFInstance(btpUsecase, instancename)
+    elif targetEnvironment == "kymaruntime":
+        statusResponse = getStatusResponseFromCreatedKymaInstance(btpUsecase, instancename)
+    elif targetEnvironment == "other":
+        statusResponse = getStatusResponseFromCreatedBTPInstance(btpUsecase, instancename)
+    return statusResponse

--- a/libs/python/helperYaml.py
+++ b/libs/python/helperYaml.py
@@ -1,0 +1,25 @@
+import yaml
+from libs.python.helperJson import getJsonFromFile
+
+
+def build_service_instance_yaml_from_parameters():
+
+    serviceInstanceTemplate = getJsonFromFile('libs/json/templates/K8s-SERVICE-INSTANCE.json')
+
+    serviceInstanceYaml = yaml.dump(serviceInstanceTemplate, default_flow_style=False)
+
+    return serviceInstanceYaml
+
+
+def build_service_binding_yaml_from_parameters():
+
+    serviceBindingTemplate = getJsonFromFile('libs/json/templates/K8s-SERVICE-BINDING.json')
+
+    serviceBindingYaml = yaml.dump(serviceBindingTemplate, default_flow_style=False)
+
+    return serviceBindingYaml
+
+
+def store_yaml_to_disk(yamlFilePath, yamlContent):
+    with open(yamlFilePath, 'w') as outfile:
+        outfile.write(yamlContent)

--- a/libs/python/helperYaml.py
+++ b/libs/python/helperYaml.py
@@ -2,9 +2,19 @@ import yaml
 from libs.python.helperJson import getJsonFromFile
 
 
-def build_service_instance_yaml_from_parameters():
+def build_service_instance_yaml_from_parameters(service):
 
     serviceInstanceTemplate = getJsonFromFile('libs/json/templates/K8s-SERVICE-INSTANCE.json')
+
+    serviceInstanceTemplate.metadata.name = service.instanceName
+    serviceInstanceTemplate.spec.serviceOfferingName = service.name
+    serviceInstanceTemplate.spec.servicePlanName = service.plan
+    serviceInstanceTemplate.spec.externalName = service.instanceName
+
+    if service.parameters is not None:
+        serviceInstanceTemplate.spec.parameters = service.parameters
+    elif service.serviceparameterfile is not None:
+        serviceInstanceTemplate.spec.parameters = getJsonFromFile(service.serviceparameterfile)       
 
     serviceInstanceYaml = yaml.dump(serviceInstanceTemplate, default_flow_style=False)
 
@@ -22,4 +32,5 @@ def build_service_binding_yaml_from_parameters():
 
 def store_yaml_to_disk(yamlFilePath, yamlContent):
     with open(yamlFilePath, 'w') as outfile:
-        outfile.write(yamlContent)
+        yaml.dump(yamlContent, outfile)
+    return True

--- a/schemas/btpsa-parameters.json
+++ b/schemas/btpsa-parameters.json
@@ -133,6 +133,18 @@
             "title": "name for the CF space",
             "default": "development"
         },
+        "k8snamespace": {
+            "type": "string",
+            "description": "name for the Kubernetes namespace to be used for your use case",
+            "title": "name for the Kubernetes namespace",
+            "default": "default"
+        },
+        "kubeconfigpath": {
+            "type": "string",
+            "description": "path to kubeconfig file to be used for your use case",
+            "title": "path to kubeconfig file",
+            "default": ".kube/config"
+        },
         "iashost": {
             "type": [
                 "string",

--- a/schemas/btpsa-usecase.json
+++ b/schemas/btpsa-usecase.json
@@ -87,7 +87,7 @@
                         "description": "environment in which the service should be created",
                         "title": "environment in which the service should be created",
                         "default": "cloudfoundry",
-                        "enum": ["cloudfoundry", "kymaruntime"]
+                        "enum": ["cloudfoundry", "kymaruntime", "other"]
                     },
                     "plan": {
                         "type": "string",


### PR DESCRIPTION
This PR contains the changes necessary to allow a creation for service instances and service bindings for:

- Cloud Foundry (via service broker processed by CF CLI)
- Kyma (via BTP operator processed by kubectl and defined via CRDs)
- Other (generic service creation via BTP CLI)

This fulfills the requested functionality in the feature request #93 