### PR TITLE
update tool for new default use case

### DIFF
--- a/.github/workflows/integration-test-full.yml
+++ b/.github/workflows/integration-test-full.yml
@@ -18,11 +18,11 @@ jobs:
       BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
       BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
     steps:
-      - name: "Integration test 02: Deploy full-stack CAP application running in SAP Launchpad"
+      - name: 'Integration test 01: Build resilient apps"'
         if: ${{ always() }}
         working-directory: /home/user
         shell: bash
-        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest02.json'
+        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest01.json'
       - name: "Integration test 04: Only app subscriptions"
         if: ${{ always() }}
         working-directory: /home/user

--- a/.github/workflows/integration-test-slim.yml
+++ b/.github/workflows/integration-test-slim.yml
@@ -18,11 +18,16 @@ jobs:
             BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
             BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
         steps:
-            - name: 'Integration test 02: Deploy full-stack CAP application running in SAP Launchpad'
+            - name: 'Integration test 01: Build resilient apps"'
+              if: ${{ always() }}
+              working-directory: /home/user
+              shell: bash
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest01.json'
+            - name: 'Integration test 07: Setup SAP Task Center"'
               if: ${{ always() }}
               working-directory: /home/user
               shell: bash 
-              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest02.json'              
+              run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest07.json'              
             - name: 'Integration test 04: Only app subscriptions'
               if: ${{ always() }}
               working-directory: /home/user

--- a/.github/workflows/stage-integration-test-full.yml
+++ b/.github/workflows/stage-integration-test-full.yml
@@ -71,11 +71,16 @@ jobs:
       BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
       BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
     steps:
-      - name: "Integration test 02: Deploy full-stack CAP application running in SAP Launchpad"
+      - name: 'Integration test 01: Build resilient apps"'
         if: ${{ always() }}
         working-directory: /home/user
         shell: bash
-        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest02.json'
+        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest01.json'
+      - name: 'Integration test 07: Setup SAP Task Center"'
+        if: ${{ always() }}
+        working-directory: /home/user
+        shell: bash
+        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest07.json'
       - name: "Integration test 04: Only app subscriptions"
         if: ${{ always() }}
         working-directory: /home/user
@@ -91,11 +96,6 @@ jobs:
         working-directory: /home/user
         shell: bash
         run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest06.json'
-      - name: 'Integration test 07: Setup SAP Task Center"'
-        if: ${{ always() }}
-        working-directory: /home/user
-        shell: bash
-        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest07.json'
       - name: "Integration test 10: Setup a Kyma environment on GCP"
         if: ${{ always() }}
         working-directory: /home/user

--- a/.github/workflows/stage-integration-test-slim.yml
+++ b/.github/workflows/stage-integration-test-slim.yml
@@ -71,11 +71,16 @@ jobs:
       BTPSA_PARAM_GLOBALACCOUNT: ${{ secrets.BTPSA_PARAM_GLOBALACCOUNT }}
       BTPSA_PARAM_MYPASSWORD: ${{ secrets.BTPSA_PARAM_MYPASSWORD }}
     steps:
-      - name: "Integration test 02: Deploy full-stack CAP application running in SAP Launchpad"
+      - name: 'Integration test 01: Build resilient apps"'
         if: ${{ always() }}
         working-directory: /home/user
         shell: bash
-        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest02.json'
+        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest01.json'
+      - name: 'Integration test 07: Setup SAP Task Center"'
+        if: ${{ always() }}
+        working-directory: /home/user
+        shell: bash
+        run: ./btpsa -parameterfile 'https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/tests/integrationtests/parameterfiles/integrationtest07.json'
       - name: "Integration test 04: Only app subscriptions"
         if: ${{ always() }}
         working-directory: /home/user

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -83,7 +83,7 @@ ARG BTPSA_VERSION_GIT_ARG=default
 ##################################################################################################################################################
 # Now putting all pieces together 
 ##################################################################################################################################################
-FROM python:3.9.9-alpine3.15 AS final_build
+FROM python:3.9-alpine3.16 AS final_build
 ENV USERNAME=user
 ENV HOME_FOLDER /home/$USERNAME
 ENV LIBS_FOLDER $HOME_FOLDER/libs
@@ -124,10 +124,12 @@ RUN adduser \
     ## Set the right timezone in the container image
     && cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
 ##########################################################################################
-# Install CAP CDS
+# Install CAP CDS 
+# - currently (Jun 7th, 2022) it's no longer possible to install CDS
+# - to be determined what the root cause is (seems related to deprecation of v1.x Cloud SDK)
 ##########################################################################################
-    && npm install -g @sap/cds-dk --allow-root \
-    && npm cache clean --force \
+    # && npm install -g @sap/cds-dk --allow-root \
+    # && npm cache clean --force \
 ##########################################################################################
 # Add user to sudo user
 ##########################################################################################

--- a/parameters.json
+++ b/parameters.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/libs/btpsa-parameters.json",
-  "usecasefile": "usecases/released/cap_app_launchpad.json",
+  "usecasefile": "usecases/released/build_resilient_apps_free_tier.json",
   "region": "us10",
   "globalaccount": null,
   "myemail": null,

--- a/tests/integrationtests/parameterfiles/integrationtest01.json
+++ b/tests/integrationtests/parameterfiles/integrationtest01.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/libs/btpsa-parameters.json",
+  "usecasefile": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/usecases/released/build_resilient_apps_free_tier.json",
+  "loginmethod": "envVariables",
+  "prunesubaccount": true,
+  "subaccountname": "BTPSA int-test resilient apps"
+}

--- a/usecases/inDevelopment/cap_app_launchpad.json
+++ b/usecases/inDevelopment/cap_app_launchpad.json
@@ -4,8 +4,8 @@
     "name": "Deploy full-stack CAP application running in SAP Launchpad (on productive SAP BTP account)",
     "description": "This usecase provides all necessary information to create the necessary service instances and app subscription for a CAP application and to deploy that application on a SAP BTP account.",
     "author": "rui.nogueira@sap.com",
-    "testStatus": "tested successfully",
-    "usageStatus": "READY TO BE USED",
+    "testStatus": "not tested",
+    "usageStatus": "NOT READY TO BE USED",
     "relatedLinks": [
       "https://developers.sap.com/tutorials/btp-app-launchpad-service.html"
     ]


### PR DESCRIPTION
Installing CDS is currently not possible. Therefore the default use case (deploying CAP app) was switched to a use case that doesn't need CDS.
CDS was as well removed from the Dockerfile.