### PR TITLE
fix for environment loop

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -417,7 +417,7 @@ class BTPUSECASE:
                     if envEntry is not None:
                         log.info("Kyma environment with name >" +
                                  kymaClusterName + "< already exists - Creation skipped")
-                        return
+                        continue
 
                     log.header("Create environment >" + environment.name + "<")
 


### PR DESCRIPTION
Loop over Environment creation has a non-deterministic behavior. This fixes the setup in mixed environment (Kyma, CF)