### PR TITLE
Consider org name provided by user

### DIFF
--- a/libs/python/helperGeneric.py
+++ b/libs/python/helperGeneric.py
@@ -74,7 +74,8 @@ def createSubaccountName(btpUsecase):
     else:
         result = "BTP setup automator (" + btpUsecase.region + ")"
 
-    btpUsecase.accountMetadata = addKeyValuePair(btpUsecase.accountMetadata, "subaccount", result)
+    btpUsecase.accountMetadata = addKeyValuePair(
+        btpUsecase.accountMetadata, "subaccount", result)
 
     return result
 
@@ -105,7 +106,8 @@ def createSubdomainID(btpUsecase):
     if btpUsecase.subdomain is not None and btpUsecase.subdomain != "":
         result = btpUsecase.subdomain.strip()
     else:
-        result = btpUsecase.accountMetadata["subaccount"] + "-" + btpUsecase.accountMetadata["global_account_id"]
+        result = btpUsecase.accountMetadata["subaccount"] + \
+            "-" + btpUsecase.accountMetadata["global_account_id"]
 
     result = re.sub(r"[^\w\s]", '-', result)
     result = result.replace(" ", "-")
@@ -116,7 +118,8 @@ def createSubdomainID(btpUsecase):
         result = result[:-1]
     result = result[:60].lower()
 
-    btpUsecase.accountMetadata = addKeyValuePair(btpUsecase.accountMetadata, "subdomain", result)
+    btpUsecase.accountMetadata = addKeyValuePair(
+        btpUsecase.accountMetadata, "subdomain", result)
 
     return result
 
@@ -124,7 +127,10 @@ def createSubdomainID(btpUsecase):
 def createOrgName(btpUsecase, envName):
     result = None
     if envName == "cloudfoundry":
-        result = "cf-" + btpUsecase.accountMetadata["subdomain"]
+        if btpUsecase.org is not None and btpUsecase.org != "":
+            result = btpUsecase.org
+        else:
+            result = "cf-" + btpUsecase.accountMetadata["subdomain"]
     if envName == "kymaruntime":
         result = "kyma-" + btpUsecase.accountMetadata["subdomain"]
     if envName != "kymaruntime" and envName != "cloudfoundry":
@@ -148,8 +154,10 @@ def buildUrltoSubaccount(btpUsecase):
     else:
         url = "https://cockpit." + region + ".hana.ondemand.com/cockpit/#/"
 
-    url += "globalaccount/" + btpUsecase.accountMetadata["global_account_id"] + "/"
-    url += "subaccount/" + btpUsecase.accountMetadata["subaccountid"] + "/service-instances"
+    url += "globalaccount/" + \
+        btpUsecase.accountMetadata["global_account_id"] + "/"
+    url += "subaccount/" + \
+        btpUsecase.accountMetadata["subaccountid"] + "/service-instances"
 
     return url
 


### PR DESCRIPTION
The org name is not considered if no org id is provided. This leads to the default org name instead of the provided one