### PR TITLE
Minor tweaks to run scripts and docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Then look for the container by name (`btp-setup-automator`) and selecting it:
 
 ![select running container in VS Code](docs/pics/quick-guide-step01.png)
 
+> You may see a message in VS Code informing you about the installation of some VS Code mechanisms into the container (to support the attachment to the remote container) and may have to wait a minute or two for this to complete.
+
 ## Use BTP-SETUP-AUTOMATOR
 
 You can run the container directly via the terminal or within VS Code, modify use case file and parameter file or supply externally available use case and parameter file.

--- a/README.md
+++ b/README.md
@@ -142,15 +142,49 @@ Then look for the container by name (`btp-setup-automator`) and selecting it:
 
 > You may see a message in VS Code informing you about the installation of some VS Code mechanisms into the container (to support the attachment to the remote container) and may have to wait a minute or two for this to complete.
 
-## Use BTP-SETUP-AUTOMATOR
+## Using the Setup Automator
 
 You can run the container directly via the terminal or within VS Code, modify use case file and parameter file or supply externally available use case and parameter file.
 
 [Read the detailed instructions](docs/README.md) on how to setup your SAP BTP account for a use case with the `btp-setup-automator`.
 
-If you want a more detailed walk-through guiding you through the first steps with the btp-setup-automator, then this video on YouTube is worth a look:
+### With VS Code
+
+If you want a more detailed walk-through guiding you through the first steps with the btp-setup-automator and VS Code, then this video on YouTube is worth a look:
 
 [![Watch the intro video on the btp-setup-automator](docs/pics/btp-setup-automator-intro-video.png)](https://youtu.be/BHBgQ45fgIk)
+
+### From a terminal
+
+You can also attach to the running container and execute a shell in there:
+
+```bash
+docker exec -it btp-setup-automator bash
+```
+
+You'll be placed in a new Bash shell inside the container, with access to all the tools:
+
+```text
+; docker exec -it btp-setup-automator bash
+bash-5.1$ ls
+LICENSE  LICENSES  README.md  btpsa  config  docs  generator  libs  parameters.json  tests  usecases
+bash-5.1$ btp
+Welcome to the SAP BTP command line interface (client v2.24.0)
+
+Usage: btp [OPTIONS] ACTION GROUP/OBJECT PARAMS
+
+CLI server URL:                    not set
+User:                              not set
+Configuration:                     /home/user/.config/btp/config.json
+
+You are currently not logged in.
+
+Tips:
+    To log in to a global account of SAP BTP, use 'btp login'. For help on login, use 'btp help login'.
+    To display general help, use 'btp help'.
+
+bash-5.1$
+```
 
 ## Known Issues
 

--- a/run
+++ b/run
@@ -16,7 +16,7 @@ if [ "$1" != "RunFromRegistry" ]; then
     echo -e "${GREEN}Building the container image ...${NOCOLOR}"
     docker image build -t ${thisname}:latest -f "config/Dockerfile"  .
 
-    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
+    echo -e "${GREEN}Starting the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
     docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "${thisname}" "${thisname}" 
 
 else
@@ -24,7 +24,7 @@ else
     echo -e "${GREEN}Pulling container image from registry ...${NOCOLOR}"
     docker pull ghcr.io/sap-samples/btp-setup-automator:main
 
-    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
+    echo -e "${GREEN}Starting the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
     docker container run --rm  -it -d --name "${thisname}" ghcr.io/sap-samples/btp-setup-automator:main 
 
 fi

--- a/run
+++ b/run
@@ -8,7 +8,7 @@ thisname="btp-setup-automator"
 echo -e "${GREEN}Cleaning up containers and images (if existing)${NOCOLOR}"
 docker container stop   "${thisname}"
 docker container rm  -f "${thisname}"
-docker image     rmi -f "${thisname}"
+docker image     rm  -f "${thisname}"
 
 
 if [ "$1" != "RunFromRegistry" ]; then

--- a/run
+++ b/run
@@ -16,7 +16,7 @@ if [ "$1" != "RunFromRegistry" ]; then
     echo -e "${GREEN}Building the container image ...${NOCOLOR}"
     docker image build -t ${thisname}:latest -f "config/Dockerfile"  .
 
-    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VSCode${NOCOLOR}"
+    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
     docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "${thisname}" "${thisname}" 
 
 else
@@ -24,7 +24,7 @@ else
     echo -e "${GREEN}Pulling container image from registry ...${NOCOLOR}"
     docker pull ghcr.io/sap-samples/btp-setup-automator:main
 
-    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VSCode${NOCOLOR}"
+    echo -e "${GREEN}Start the container as '${thisname}' - Access possible e.g. via VS Code${NOCOLOR}"
     docker container run --rm  -it -d --name "${thisname}" ghcr.io/sap-samples/btp-setup-automator:main 
 
 fi

--- a/run.bat
+++ b/run.bat
@@ -5,7 +5,7 @@ call :setESC
 echo %ESC%[32mCleaning up containers and images (if existing)%ESC%[0m
 docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
-docker image     rmi -f "btp-setup-automator"
+docker image     rm  -f "btp-setup-automator"
 
 
 if not "%1" == "RunFromRegistry" (

--- a/run.bat
+++ b/run.bat
@@ -13,7 +13,7 @@ if not "%1" == "RunFromRegistry" (
   echo %ESC%[32mBuilding the container image ...%ESC%[0m
   docker image     build -t btp-setup-automator:latest -f .\config\Dockerfile .
 
-  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
+  echo %ESC%[32mStarting the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
   docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name btp-setup-automator btp-setup-automator
 
 ) else (
@@ -21,7 +21,7 @@ if not "%1" == "RunFromRegistry" (
   echo %ESC%[32mPulling container image from registry ...%ESC%[0m
   docker pull ghcr.io/sap-samples/btp-setup-automator:main
 
-  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
+  echo %ESC%[32mStarting the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
   docker container run --rm  -it -d --name btp-setup-automator ghcr.io/sap-samples/btp-setup-automator:main
 
 )

--- a/run.bat
+++ b/run.bat
@@ -13,7 +13,7 @@ if not "%1" == "RunFromRegistry" (
   echo %ESC%[32mBuilding the container image ...%ESC%[0m
   docker image     build -t btp-setup-automator:latest -f .\config\Dockerfile .
 
-  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VSCode%ESC%[0m
+  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
   docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name btp-setup-automator btp-setup-automator
 
 ) else (
@@ -21,7 +21,7 @@ if not "%1" == "RunFromRegistry" (
   echo %ESC%[32mPulling container image from registry ...%ESC%[0m
   docker pull ghcr.io/sap-samples/btp-setup-automator:main
 
-  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VSCode%ESC%[0m
+  echo %ESC%[32mStart the container as 'btp-setup-automator' - Access possible e.g. via VS Code%ESC%[0m
   docker container run --rm  -it -d --name btp-setup-automator ghcr.io/sap-samples/btp-setup-automator:main
 
 )

--- a/run.ps1
+++ b/run.ps1
@@ -14,7 +14,7 @@ if ( $RunFromRegistry -eq $False )
     Write-Host "Building the container image ..." -ForegroundColor green
     docker image build -t btp-setup-automator:latest -f "config/Dockerfile"  .
 
-    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode" -ForegroundColor green
+    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
     docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
 }
 else
@@ -22,6 +22,6 @@ else
     Write-Host "Pulling container image from registry ..." -ForegroundColor green
     docker pull ghcr.io/sap-samples/btp-setup-automator:main 
 
-    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VSCode" -ForegroundColor green
+    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
     docker container run --rm  -it -d --name "btp-setup-automator" ghcr.io/sap-samples/btp-setup-automator:main 
 }

--- a/run.ps1
+++ b/run.ps1
@@ -14,7 +14,7 @@ if ( $RunFromRegistry -eq $False )
     Write-Host "Building the container image ..." -ForegroundColor green
     docker image build -t btp-setup-automator:latest -f "config/Dockerfile"  .
 
-    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
+    Write-Host "Starting the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
     docker container run -e BTPSA_VERSION_GIT="$(git describe --long --tags  --always)" --rm  -it -d --name "btp-setup-automator" "btp-setup-automator" 
 }
 else
@@ -22,6 +22,6 @@ else
     Write-Host "Pulling container image from registry ..." -ForegroundColor green
     docker pull ghcr.io/sap-samples/btp-setup-automator:main 
 
-    Write-Host "Start the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
+    Write-Host "Starting the container as 'btp-setup-automator' - Access possible e.g. via VS Code" -ForegroundColor green
     docker container run --rm  -it -d --name "btp-setup-automator" ghcr.io/sap-samples/btp-setup-automator:main 
 }

--- a/run.ps1
+++ b/run.ps1
@@ -7,7 +7,7 @@ Param(
 Write-Host "Cleaning up containers and images (if existing)" -ForegroundColor green
 docker container stop   "btp-setup-automator"
 docker container rm  -f "btp-setup-automator"
-docker image     rmi -f "btp-setup-automator"
+docker image     rm  -f "btp-setup-automator"
 
 if ( $RunFromRegistry -eq $False )
 {


### PR DESCRIPTION
I tweaked the `run` scripts:

* move away from older style Docker commands (`rmi` is a remnant of the old style, and is included as an alias only for backwards compatibility, I think)
* make it clear that _the script_ is the one that is starting the container, not that the user has to start it
* VS Code is written with a space

I also added a note to the main README about having to wait for VS Code remote container mechanisms being installed in the container.

I also reworked the "Use" section to add a brief hint about connecting directly to the container (without VS Code).