### PR TITLE
Feature: Specification of CF landscape when creating CF org

### DIFF
--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -163,6 +163,15 @@
                 }
             }
         },
+        "cfLandscape":{
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "landscape of the Cloud Foundry environment to be used for your use case (e.g. cf-eu10-004)",
+            "title": "landscape of the CF environment for use case",
+            "default": null
+        },
         "iashost": {
             "type": [
                 "string",

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -163,6 +163,15 @@
                 }
             }
         },
+        "cfLandscape":{
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "landscape of the Cloud Foundry environment to be used for your use case (e.g. cf-eu10-004)",
+            "title": "landscape of the CF environment for use case",
+            "default": null
+        },
         "iashost": {
             "type": [
                 "string",

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1387,9 +1387,10 @@ def pruneUseCaseAssets(btpUsecase: BTPUSECASE):
                         "service instance >" + service["instancename"] + "< for service >" + service["name"] + "< now deleted.")
                     service["deletionStatus"] = "deleted"
                 else:
-                    log.info("service instance >" + service["instancename"] + "< for service >" + service["name"] + "< not yet deleted. Checking again in " + str(search_every_x_seconds) + " seconds.")
+                    log.info("service instance >" + service["instancename"] + "< for service >" + service["name"] +
+                             "< not yet deleted. Checking again in " + str(search_every_x_seconds) + " seconds.")
                     service["deletionStatus"] = status
-                    
+
             time.sleep(search_every_x_seconds)
             current_time += search_every_x_seconds
             allServicesDeleted = True
@@ -1497,9 +1498,14 @@ def selectEnvironmentLandscape(btpUsecase: BTPUSECASE, environment):
                 environmentType = item["environmentType"]
                 if "landscapeLabel" not in item:
                     return None
-                # Simply take the first landscape that is found, matching the environment and the plan
                 if environment.plan == servicePlan and environment.name == environmentType:
-                    return item["landscapeLabel"]
+                    if btpUsecase.landscape is None:
+                        # if no landscape was defined in parameters.json, take the first landscape that is found, matching the environment and the plan
+                        return item["landscapeLabel"]
+                    elif btpUsecase.landscape is not None and btpUsecase.landscape == item["landscapeLabel"]:
+                        # if landscape was defined in parameters.json, take the entry matching the environment, plan and landsacpe
+                        return item["landscapeLabel"]
+
         time.sleep(search_every_x_seconds)
         current_time += search_every_x_seconds
 

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1499,10 +1499,10 @@ def selectEnvironmentLandscape(btpUsecase: BTPUSECASE, environment):
                 if "landscapeLabel" not in item:
                     return None
                 if environment.plan == servicePlan and environment.name == environmentType:
-                    if btpUsecase.landscape is None:
+                    if btpUsecase.cfLandscape is None:
                         # if no landscape was defined in parameters.json, take the first landscape that is found, matching the environment and the plan
                         return item["landscapeLabel"]
-                    elif btpUsecase.landscape is not None and btpUsecase.landscape == item["landscapeLabel"]:
+                    elif btpUsecase.cfLandscape is not None and btpUsecase.cfLandscape == item["landscapeLabel"]:
                         # if landscape was defined in parameters.json, take the entry matching the environment, plan and landsacpe
                         return item["landscapeLabel"]
 


### PR DESCRIPTION
This PR contains the enhancements needed to specify a dedicated landscape when creating a Cloud Foundry org in SAP BTP.

The value for the landscape must be explicitly specified (no type-ahead support implemented). The existing default behavior remains as is, so no breaking change for existing definitions 

See also issue #274 