### PR TITLE
[FEATURE REQUEST] Support of custom IdPs in Role assignment

### DIFF
--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -117,6 +117,15 @@
             "title": "provider subaccount id of custom app on SAP BTP",
             "default": null
         },
+        "defaultIdp": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "default identity provider for role collections",
+            "title": "default IdP",
+            "default": null
+        },
         "directoryid": {
             "type": [
                 "string",

--- a/config/templates/libs/BTPSA-USECASE.json
+++ b/config/templates/libs/BTPSA-USECASE.json
@@ -91,6 +91,12 @@
                         "description": "user groups to be assigned from the parameter file",
                         "title": "user groups from parameter file"
                     },
+                    "idp":{
+                        "type": "string",
+                        "description": "the identity provider that hosts the user. ",
+                        "title": "IdP name",
+                        "default": null
+                    },
                     "level": {
                         "type": "string",
                         "description": "level of the role collection",
@@ -287,6 +293,12 @@
                                     "type": "array",
                                     "description": "list of user groups to assign the role collection",
                                     "title": "list of user groups to assign the role collection"
+                                },
+                                "idp":{
+                                    "type": "string",
+                                    "description": "the identity provider that hosts the user. ",
+                                    "title": "IdP name",
+                                    "default": null
                                 }
                             }
                         }

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -117,6 +117,15 @@
             "title": "provider subaccount id of custom app on SAP BTP",
             "default": null
         },
+        "defaultIdp": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "default identity provider for role collections",
+            "title": "default IdP",
+            "default": null
+        },
         "directoryid": {
             "type": [
                 "string",

--- a/libs/btpsa-usecase.json
+++ b/libs/btpsa-usecase.json
@@ -81,6 +81,12 @@
                         "description": "user groups to be assigned from the parameter file",
                         "title": "user groups from parameter file"
                     },
+                    "idp":{
+                        "type": "string",
+                        "description": "the identity provider that hosts the user",
+                        "title": "IdP name",
+                        "default": null
+                    },
                     "level": {
                         "type": "string",
                         "description": "level of the role collection",
@@ -277,6 +283,12 @@
                                     "type": "array",
                                     "description": "list of user groups to assign the role collection",
                                     "title": "list of user groups to assign the role collection"
+                                },
+                                "idp":{
+                                    "type": "string",
+                                    "description": "the identity provider that hosts the user. ",
+                                    "title": "IdP name",
+                                    "default": null
                                 }
                             }
                         }

--- a/libs/python/helperRolesAndUsers.py
+++ b/libs/python/helperRolesAndUsers.py
@@ -367,9 +367,9 @@ def determineIdpForRoleCollection(btpUsecase, rolecollection):
     # If no IdP is configured we use the default one and do not provide an IdP
     idp = None
 
-    if btpUsecase.get("defaultIdp"):
+    if btpUsecase.defaultIdp:
         # A explicit default IdP is configured
-        idp = btpUsecase.get("defaultIdp")
+        idp = btpUsecase.defaultIdp
     if rolecollection.get("idp"):
         # A role collection specific IdP is configured - overrules the default IdP
         idp = rolecollection.get("idp")


### PR DESCRIPTION
This PR contains the enhancements in the btpsa code as well as in the JSON schemas to support the IdP parameter when assigning role collections.

The IdP can be defined on two levels:

- parameters.json: Default provider that will be used for all role collections if none is specified in the role collections
- usecase.json: per role collection a specific IdP can be defined that overrules the default one from the parameters.json

If there is no IdP is provided at all the default of the btp CLI is used 