### PR TITLE
Add dependabot configuration for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
+      # Check for updates to GitHub Actions once a week on Monday
       interval: "weekly"
       day: "monday"
   - package-ecosystem: "pip"
     directory: "/config/python"
     schedule:
-      # Check for updates to GitHub Actions every weekday
+      # Check for updates to GitHub Actions once a week on Monday
       interval: "weekly"
       day: "monday"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions once a week on Monday
+      interval: "weekly"
+      day: "monday"    
    


### PR DESCRIPTION
This PR adds the dependabot config for the ecosystem "npm"