### PR TITLE
Labeling of resources

### DIFF
--- a/config/templates/K8S/K8s-SERVICE-BINDING.json
+++ b/config/templates/K8S/K8s-SERVICE-BINDING.json
@@ -2,7 +2,8 @@
     "apiVersion": "services.cloud.sap.com/v1",
     "kind": "ServiceBinding",
     "metadata": {
-        "name": "my-service-binding"
+        "name": "my-service-binding",
+        "labels": {}
     },
     "spec": {
         "serviceInstanceName": "my-service-instance",

--- a/config/templates/K8S/K8s-SERVICE-INSTANCE.json
+++ b/config/templates/K8S/K8s-SERVICE-INSTANCE.json
@@ -2,7 +2,8 @@
     "apiVersion": "services.cloud.sap.com/v1",
     "kind": "ServiceInstance",
     "metadata": {
-        "name": "my-service-instance"
+        "name": "my-service-instance",
+        "labels": {}
     },
     "spec": {
         "serviceOfferingName": "sample-service",

--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -144,6 +144,12 @@
             "title": "directory name for use case",
             "default": null
         },
+        "directorylabels":{
+            "type": "object",
+            "description": "labels for the directory",
+            "title": "directory labels",
+            "default": null
+        },
         "envvariables": {
             "type": "object",
             "description": "list of environment variables on OS level to be used within commands defined in the `executeBeforeAccountSetup` and `executeAfterAccountSetup`.",
@@ -337,6 +343,12 @@
             "type": "string",
             "description": "id of your sub account that should be used",
             "title": "subaccount id of SAP BTP sub account",
+            "default": null
+        },
+        "subaccountlabels":{
+            "type": "object",
+            "description": "labels for your sub account",
+            "title": "sub account labels",
             "default": null
         },
         "subaccountname": {

--- a/config/templates/libs/BTPSA-USECASE.json
+++ b/config/templates/libs/BTPSA-USECASE.json
@@ -236,6 +236,11 @@
                         "description": "name of the service instance",
                         "title": "name of the service instance"
                     },
+                    "labels":{
+                        "type": "object",
+                        "description": "labels for the service",
+                        "title": "labels for the service"
+                    },
                     "name": {
                         "type": "string",
                         "description": "name of the service",
@@ -307,6 +312,16 @@
                         "type": "array",
                         "description": "list of services that need to be instantiated before instantiating this service",
                         "title": "list of services that need to be instantiated before instantiating this service",
+                        "default": []
+                    },
+                    "serviceKeyLabels":{
+                        "type": "array",
+                        "additionalProperties": false,
+                        "description": "labels for service keys as JSON",
+                        "title": "labels for service keys",
+                        "items": {
+                            "type": "object"
+                        },
                         "default": []
                     },
                     "serviceparameterfile": {

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -135,6 +135,12 @@
             "title": "directory id in SAP BTP global account",
             "default": null
         },
+        "directorylabels":{
+            "type": "object",
+            "description": "labels for the directory",
+            "title": "directory labels",
+            "default": null
+        },
         "directoryname": {
             "type": [
                 "string",
@@ -346,6 +352,12 @@
             ],
             "description": "name of your sub account in case you want to define a specific name for your sub account",
             "title": "sub account name for use case",
+            "default": null
+        },
+        "subaccountlabels":{
+            "type": "object",
+            "description": "labels for your sub account",
+            "title": "sub account labels",
             "default": null
         },
         "subdomain": {

--- a/libs/btpsa-usecase.json
+++ b/libs/btpsa-usecase.json
@@ -226,6 +226,11 @@
                         "description": "name of the service instance",
                         "title": "name of the service instance"
                     },
+                    "labels":{
+                        "type": "object",
+                        "description": "labels for the service",
+                        "title": "labels for the service"
+                    },
                     "name": {
                         "type": "string",
                         "description": "name of the service",
@@ -246,7 +251,6 @@
                         "description": "catalog name of the service plan",
                         "title": "catalog name of the service plan"
                     },
-                    
                     "relatedLinks": {
                         "type": "array",
                         "description": "links related to this service",
@@ -297,6 +301,16 @@
                         "type": "array",
                         "description": "list of services that need to be instantiated before instantiating this service",
                         "title": "list of services that need to be instantiated before instantiating this service",
+                        "default": []
+                    },
+                    "serviceKeyLabels":{
+                        "type": "array",
+                        "additionalProperties": false,
+                        "description": "labels for service keys as JSON",
+                        "title": "labels for service keys",
+                        "items": {
+                            "type": "object"
+                        },
                         "default": []
                     },
                     "serviceparameterfile": {

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -5,7 +5,7 @@ from libs.python.helperJson import addKeyValuePair, dictToString, convertStringT
 from libs.python.helperBtpTrust import runTrustFlow
 from libs.python.helperCommandExecution import executeCommandsFromUsecaseFile, runShellCommand, runCommandAndGetJsonResult, runShellCommandFlex, login_btp, login_cf
 from libs.python.helperEnvCF import checkIfCFEnvironmentAlreadyExists, checkIfCFSpaceAlreadyExists, getCfApiEndpointByUseCase, getCfApiEndpointFromLabels, try_until_cf_space_done, try_until_space_quota_created
-from libs.python.helperServiceInstances import createServiceKey, deleteServiceInstance, deleteServiceKeysAndWait, getServiceDeletionStatus, initiateCreationOfServiceInstances, checkIfAllServiceInstancesCreated
+from libs.python.helperServiceInstances import createServiceKey, deleteServiceInstance, deleteServiceKeysAndWait, getServiceDeletionStatus, initiateCreationOfServiceInstances, checkIfAllServiceInstancesCreated, handleLabelsForCF
 from libs.python.helperGeneric import buildUrltoSubaccount, getNamingPatternForServiceSuffix, createDirectoryName, createSubaccountName, createSubdomainID, createOrgName, save_collected_metadata
 from libs.python.helperFileAccess import writeKubeConfigFileToDefaultDir
 from libs.python.helperEnvKyma import extractKymaDashboardUrlFromEnvironmentDataEntry, getKymaEnvironmentInfoByClusterName, getKymaEnvironmentStatusFromEnvironmentDataEntry, extractKymaKubeConfigUrlFromEnvironmentDataEntry, getKymaEnvironmentIdByClusterName
@@ -150,6 +150,10 @@ class BTPUSECASE:
                     --display-name '" + directory + "' \
                     --global-account '" + globalAccount + "'"
 
+                if self.directorylabels is not None:
+                    labelsAsString = json.dumps(self.subaccountlabels)
+                    command += " --labels '" + labelsAsString + "'"
+                       
                 message = "Create directory >" + directory + "<"
 
                 result = runCommandAndGetJsonResult(
@@ -329,6 +333,10 @@ class BTPUSECASE:
                     --region '" + usecaseRegion + "' \
                     --subaccount-admins '" + subaccountadmins + "'"
 
+                if self.subaccountlabels is not None:
+                    labelsAsString = json.dumps(self.subaccountlabels)
+                    command += " --labels '" + labelsAsString + "'"
+                 
                 message = "Create sub account >" + subaccount + "<"
 
                 if directoryid is not None and directoryid != "":
@@ -736,9 +744,7 @@ class BTPUSECASE:
         self.accountMetadata = self.createServiceKeys()
         save_collected_metadata(self)
 
-        # btp_assign_role_collection_to_admins(self)
-
-        save_collected_metadata(self)
+        handleLabelsForCF(btpUsecase=self)
 
     def createServiceKeys(self):
         accountMetadata = self.accountMetadata

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -4,8 +4,8 @@ from libs.python.helperFolders import FOLDER_SCHEMA_LIBS
 from libs.python.helperJson import addKeyValuePair, dictToString, convertStringToJson, getJsonFromFile
 from libs.python.helperBtpTrust import runTrustFlow
 from libs.python.helperCommandExecution import executeCommandsFromUsecaseFile, runShellCommand, runCommandAndGetJsonResult, runShellCommandFlex, login_btp, login_cf
-from libs.python.helperEnvCF import checkIfCFEnvironmentAlreadyExists, checkIfCFSpaceAlreadyExists, getCfApiEndpointByUseCase, getCfApiEndpointFromLabels, try_until_cf_space_done, try_until_space_quota_created
-from libs.python.helperServiceInstances import createServiceKey, deleteServiceInstance, deleteServiceKeysAndWait, getServiceDeletionStatus, initiateCreationOfServiceInstances, checkIfAllServiceInstancesCreated, handleLabelsForCF
+from libs.python.helperEnvCF import checkIfCFEnvironmentAlreadyExists, checkIfCFSpaceAlreadyExists, getCfApiEndpointByUseCase, getCfApiEndpointFromLabels, try_until_cf_space_done, try_until_space_quota_created, handleLabelsForCF
+from libs.python.helperServiceInstances import createServiceKey, deleteServiceInstance, deleteServiceKeysAndWait, getServiceDeletionStatus, initiateCreationOfServiceInstances, checkIfAllServiceInstancesCreated
 from libs.python.helperGeneric import buildUrltoSubaccount, getNamingPatternForServiceSuffix, createDirectoryName, createSubaccountName, createSubdomainID, createOrgName, save_collected_metadata
 from libs.python.helperFileAccess import writeKubeConfigFileToDefaultDir
 from libs.python.helperEnvKyma import extractKymaDashboardUrlFromEnvironmentDataEntry, getKymaEnvironmentInfoByClusterName, getKymaEnvironmentStatusFromEnvironmentDataEntry, extractKymaKubeConfigUrlFromEnvironmentDataEntry, getKymaEnvironmentIdByClusterName
@@ -1490,7 +1490,7 @@ def pruneUseCaseAssets(btpUsecase: BTPUSECASE):
 
         # Set the deletion status to "not deleted"
         for service in accountMetadata["createdAppSubscriptions"]:
-            if service.get("entitleonly") == False:
+            if service.get("entitleonly") is False:
                 service["deletionStatus"] = "not deleted"
             else:
                 service["deletionStatus"] = "deleted"

--- a/libs/python/helperEnvBTP.py
+++ b/libs/python/helperEnvBTP.py
@@ -31,6 +31,9 @@ def create_btp_service(btpUsecase, service):
     if service.parameters is not None:
         command = command + " --parameters '" + dictToString(service.parameters) + "'"
 
+    if service.labels is not None:
+        command = command + " --labels '" + dictToString(service.labels) + "'"     
+
     message = "Create instance >" + service.instancename + "< for service >" + \
         service.name + "< and plan >" + service.plan + "<" + " via BTP CLI"
 
@@ -53,12 +56,16 @@ def getStatusResponseFromCreatedBTPInstance(btpUsecase, instancename, service):
     return jsonResult
 
 
-def createBtpServiceBinding(btpUsecase, instanceId, instanceName, keyName):
+def createBtpServiceBinding(btpUsecase, instanceId, instanceName, keyName, keyLabels):
     result = None
 
     command = "btp --format JSON create services/binding --name " + keyName + " --service-instance " + \
         instanceId + " --subaccount " + \
         btpUsecase.accountMetadata.get("subaccountid")
+    
+    if keyLabels is not None:
+        command = command + " --labels '" + dictToString(keyLabels) + "'"
+
     message = "create service key for service instance >" + \
         instanceName + "< for keyname >" + keyName + "<"
 

--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -292,3 +292,43 @@ def get_cf_service_deletion_status(btpUsecase, service):
         return "deleted"
     else:
         return "not deleted"
+
+
+def handleLabelsForCF(btpUsecase):
+    # if labels are defined for CF services the need to be attached after service/service key creation
+    # see https://cli.cloudfoundry.org/en-US/v8/set-label.html
+
+    for serviceInstance in btpUsecase.accountMetadata.get("createdServiceInstances"):
+        if serviceInstance.get("entitleonly") is not False or serviceInstance.get("category") != "SERVICE" or serviceInstance.get("targetenvironment") != "cloudfoundry":
+            # Basic check if service is in scope of attaching labels => Only CF services
+            continue
+
+        if serviceInstance.get("labels") is None:
+            # Check for labels to put on service
+            continue
+
+        labelString = transformLabelJsonToCFString(serviceInstance.get("labels"))
+
+        command = "cf set-label service-instance " + serviceInstance.get("instancename") + " " + labelString
+        message = "Set labels for CF service instance >" + serviceInstance.get("instancename") + "<"
+        runShellCommand(btpUsecase, command, "INFO", message)
+
+        # !!! SERVICE KEYS ARE NOT SUPPORTED BY CF API V8!!!
+        #if serviceInstance.get("serviceKeyLabels") is None:
+        #    # Check for label that s should be put on service key
+        #    continue
+
+        #for serviceKeyLabelEntry in serviceInstance.get("serviceKeyLabels"):
+        #    labelString = transformLabelJsonToCFString(serviceKeyLabelEntry.get("labels"))
+
+        #    command = "cf set-label service-key " + serviceKeyLabelEntry.get("name") + " " + labelString
+        #    message = "Set labels for CF service key >" + serviceKeyLabelEntry.get("name") + "<"
+        #    runShellCommand(btpUsecase, command, "INFO", message)
+
+
+def transformLabelJsonToCFString(labelJson):
+    labelString = ""
+    for key in labelJson:
+        value = ' ,'.join(labelJson[key])
+        labelString += key + "='" + value + "' "
+    return labelString.strip()

--- a/libs/python/helperEnvKyma.py
+++ b/libs/python/helperEnvKyma.py
@@ -28,12 +28,12 @@ def create_kyma_service(btpUsecase, service):
     return service
 
 
-def createKymaServiceBinding(btpUsecase, service, keyName):
+def createKymaServiceBinding(btpUsecase, service, keyName, keyLabels):
     filepath = "logs/k8s/service-binding/service-binding-" + \
         btpUsecase.accountMetadata.get("subaccountid") + ".yaml"
 
     build_and_store_service_binding_yaml_from_parameters(
-        keyName, service, filepath)
+        keyName, service, filepath, keyLabels)
 
     command = "kubectl apply -f " + filepath + " -n " + \
         btpUsecase.k8snamespace + " --kubeconfig " + btpUsecase.kubeconfigpath

--- a/libs/python/helperServiceInstances.py
+++ b/libs/python/helperServiceInstances.py
@@ -322,16 +322,27 @@ def createServiceKey(serviceKey, service, btpUsecase):
     targetenvironment = service.targetenvironment
     statusResponse = None
 
+    labels = getServiceKeyLabelsByKey(service=service, key=serviceKey)
+
     if targetenvironment == "cloudfoundry":
         statusResponse = get_cf_service_key(
             btpUsecase, service.instancename, serviceKey)
     elif targetenvironment == "kymaruntime":
         statusResponse = createKymaServiceBinding(
-            btpUsecase, service, serviceKey)
+            btpUsecase, service, serviceKey, labels)
     elif targetenvironment == "sapbtp":
-        statusResponse = createBtpServiceBinding(btpUsecase, service.id, service.instancename, serviceKey)
+        statusResponse = createBtpServiceBinding(btpUsecase, service.id, service.instancename, serviceKey, labels)
     else:
         log.error("The targetenvironment is not supported ")
         sys.exit(os.EX_DATAERR)
 
     return statusResponse
+
+
+def getServiceKeyLabelsByKey(service, key):
+    labels = None
+    if service.serviceKeyLabels is not None:
+        for entry in service.serviceKeyLabels:
+            if entry.get("name") == key:
+                labels = entry.get("labels")
+    return labels

--- a/libs/python/helperYaml.py
+++ b/libs/python/helperYaml.py
@@ -14,6 +14,9 @@ def build_and_store_service_instance_yaml_from_parameters(service, yamlFilePath)
     serviceInstanceTemplate["spec"]["servicePlanName"] = service.plan
     serviceInstanceTemplate["spec"]["externalName"] = service.instancename
 
+    if service.labels is not None:
+        serviceInstanceTemplate["metadata"]["labels"] = service.labels
+
     if service.parameters is not None:
         serviceInstanceTemplate["spec"]["parameters"] = service.parameters
     elif service.serviceparameterfile is not None:
@@ -25,12 +28,16 @@ def build_and_store_service_instance_yaml_from_parameters(service, yamlFilePath)
         yaml.dump(serviceInstanceTemplate, outfile, default_flow_style=False)
 
 
-def build_and_store_service_binding_yaml_from_parameters(keyname, service, yamlFilePath):
+def build_and_store_service_binding_yaml_from_parameters(keyname, service, yamlFilePath, keyLabels):
 
     templatePath = FOLDER_K8S_YAML_TEMPLATES + 'K8s-SERVICE-BINDING.json'
     serviceBindingTemplate = getJsonFromFile(templatePath)
 
     serviceBindingTemplate["metadata"]["name"] = keyname
+    
+    if keyLabels is not None:
+        serviceBindingTemplate["metadata"]["labels"] = keyLabels
+
     serviceBindingTemplate["spec"]["serviceInstanceName"] = service.instancename
     serviceBindingTemplate["spec"]["secretName"] = keyname
 

--- a/usecases/released/labels/parameters_labels.json
+++ b/usecases/released/labels/parameters_labels.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/libs/btpsa-parameters.json",
+    "usecasefile": "usecases/released/default.json",
+    "region": "us10",
+    "globalaccount": "<YOUR GLOBAL ACCOUNT>",
+    "myemail": "<YOUR EMAIL>",
+    "loginmethod": "sso",
+    "subaccountname": "test-labels",
+    "subaccountlabels": {
+      "costcenter": ["org-123"],
+      "appowner": ["The App Owner ID"]
+    },
+    "cfspacename": "development"
+  }
+  

--- a/usecases/released/labels/usecase_labels.json
+++ b/usecases/released/labels/usecase_labels.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://raw.githubusercontent.com/SAP-samples/btp-setup-automator/main/libs/btpsa-usecase.json",
+    "aboutThisUseCase": {
+        "name": "Default use case on how to show how btp-setup-automator works.",
+        "description": "This usecase sets up services instances of (free) service plans on SAP BTP.",
+        "author": "christian.lechner@sap.com",
+        "testStatus": "tested successfully",
+        "usageStatus": "READY TO BE USED"
+    },
+    "services": [
+        {
+            "name": "alert-notification",
+            "plan": "free",
+            "category": "SERVICE",
+            "targetenvironment": "sapbtp",
+            "labels": {
+                "costcenter": [
+                    "orga"
+                ],
+                "appowner": [
+                    "Somebody"
+                ]
+            },
+            "createServiceKeys": [
+                "serviceKeyBTP"
+            ],
+            "serviceKeyLabels": [
+                {
+                    "name": "serviceKeyBTP",
+                    "labels": {
+                        "costcenter": [
+                            "orga"
+                        ],
+                        "appowner": [
+                            "Somebody"
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces the support of labels for resources in SAP BTP.

For services and service keys the support depends on the targeted environment:

- `btp`/`other`: services and service keys support the addition of labels 
- `k8s`/`kyma`: services and service keys support the addition of labels
- `cf`: Service Instances only