### PR TITLE
harden cf API Endpoint parsing from btp response

### DIFF
--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -4,7 +4,7 @@ certifi==2022.9.24
 charset-normalizer==2.1.1
 flake8==4.0.1
 idna==3.4
-inquirer==3.0.0
+inquirer==2.10.1
 Jinja2==3.1.2
 jsonschema==4.17.0
 MarkupSafe==2.1.1

--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -4,7 +4,7 @@ certifi==2022.9.24
 charset-normalizer==2.1.1
 flake8==4.0.1
 idna==3.4
-inquirer==2.10.1
+inquirer==3.0.0
 Jinja2==3.1.2
 jsonschema==4.17.0
 MarkupSafe==2.1.1

--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -140,6 +140,9 @@ def getCfApiEndpointByUseCase(btpUsecase):
             if labels.get("API Endpoint"):
                 cf_api_endpoint = labels.get("API Endpoint")
                 break
+            elif labels.get("API Endpoint:"):
+                cf_api_endpoint = labels.get("API Endpoint")
+                break
 
     return cf_api_endpoint
 
@@ -149,6 +152,8 @@ def getCfApiEndpointFromLabels(labelsAsJson):
 
     if labelsAsJson.get("API Endpoint"):
         cf_api_endpoint = labelsAsJson.get("API Endpoint")
+    elif labelsAsJson.get("API Endpoint:"):
+        cf_api_endpoint = labelsAsJson.get("API Endpoint:")
 
     return cf_api_endpoint
 

--- a/libs/python/helperEnvCF.py
+++ b/libs/python/helperEnvCF.py
@@ -141,7 +141,7 @@ def getCfApiEndpointByUseCase(btpUsecase):
                 cf_api_endpoint = labels.get("API Endpoint")
                 break
             elif labels.get("API Endpoint:"):
-                cf_api_endpoint = labels.get("API Endpoint")
+                cf_api_endpoint = labels.get("API Endpoint:")
                 break
 
     return cf_api_endpoint


### PR DESCRIPTION
As pointed out in [this slack comment](https://sap-btp.slack.com/archives/CCXF812E9/p1659430751327569), btp responses sometimes hold the keys 
(`Org Name`, `API Endpoint`, `Org ID`) 
and unfortunately sometimes they hold the keys with added colons as part of the key 
(`Org Name:`, `API Endpoint:`, `Org ID:`). 

This change hardens the api endpoint retrieval against this nonsense response behaviour.