### PR TITLE
Make accountMetadata available as env variables

### DIFF
--- a/docs/SAMPLECONFIG.md
+++ b/docs/SAMPLECONFIG.md
@@ -219,6 +219,27 @@ Besides this basic setup information we can also specify additional parameters l
 
 > 📝 Tip - In case you struggle with the available parameters and the possible values you can either check the SAP BTP cockpit UI (JSON view when creating a service) and the help.sap.com documentation of the service.
 
+### Environment variables available for custom commands
+
+btpsa will expose account metadata as environment variables to allow you to reference it when using `executeAfterAccountSetup`. The available variables are:
+
+- `$GLOBAL_ACCOUNT_ID`: Global account UUID
+- `$GLOBALACCOUNT`: Global account subdomain
+- `$SUBACCOUNTID`: Subaccount ID
+- `$SUBDOMAIN`: Subaccount subdomain
+- `$SUBACCOUNT`: Subaccount name
+
+
+If the usecase involves Kyma, `$KYMAKUBECONFIGURL` is also available (e.g.: `https://kyma-env-broker.cp.kyma.cloud.sap/kubeconfig/<UUID>`).
+
+And for Cloud Foundry:
+
+- `$CFAPIENDPOINT`: e.g.: `https://api.cf.us10-001.hana.ondemand.com`
+- `$ORG`: Org name
+- `$ORGID`: Org ID 
+
+The only environment variable available for `executeBeforeAccountSetup` is `$GLOBAL_ACCOUNT_ID`.
+
 ### Usecase Examples
 
 You find several examples for parameter files in the folder `usecases/released`.

--- a/libs/python/helperGeneric.py
+++ b/libs/python/helperGeneric.py
@@ -180,7 +180,11 @@ def getDictWithEnvVariables(btpUsecase):
     if btpUsecase.envvariables is not None and len(btpUsecase.envvariables) > 0:
         for variable, value in btpUsecase.envvariables.items():
             os.environ[variable] = value
-        result = dict(os.environ)
+    if btpUsecase.accountMetadata is not None and len(btpUsecase.accountMetadata) > 0:
+        for variable, value in btpUsecase.accountMetadata.items():
+            if isinstance(value, str):
+                os.environ[variable.upper()] = value
+    result = dict(os.environ)
 
     return result
 


### PR DESCRIPTION
Hi!
Finally managed some time to do this.
This exposes the accountMetadata variables as environment variables when executing commands.
I included the documentation showing which variables are available.

Thanks,
Pedro