### PR TITLE
Using idp as origin for cf-cli when assigning user roles

### DIFF
--- a/docs/SAMPLECONFIG.md
+++ b/docs/SAMPLECONFIG.md
@@ -219,6 +219,27 @@ Besides this basic setup information we can also specify additional parameters l
 
 > 📝 Tip - In case you struggle with the available parameters and the possible values you can either check the SAP BTP cockpit UI (JSON view when creating a service) and the help.sap.com documentation of the service.
 
+### Environment variables available for custom commands
+
+btpsa will expose account metadata as environment variables to allow you to reference it when using `executeAfterAccountSetup`. The available variables are:
+
+- `$GLOBAL_ACCOUNT_ID`: Global account UUID
+- `$GLOBALACCOUNT`: Global account subdomain
+- `$SUBACCOUNTID`: Subaccount ID
+- `$SUBDOMAIN`: Subaccount subdomain
+- `$SUBACCOUNT`: Subaccount name
+
+
+If the usecase involves Kyma, `$KYMAKUBECONFIGURL` is also available (e.g.: `https://kyma-env-broker.cp.kyma.cloud.sap/kubeconfig/<UUID>`).
+
+And for Cloud Foundry:
+
+- `$CFAPIENDPOINT`: e.g.: `https://api.cf.us10-001.hana.ondemand.com`
+- `$ORG`: Org name
+- `$ORGID`: Org ID 
+
+The only environment variable available for `executeBeforeAccountSetup` is `$GLOBAL_ACCOUNT_ID`.
+
 ### Usecase Examples
 
 You find several examples for parameter files in the folder `usecases/released`.

--- a/libs/python/helperGeneric.py
+++ b/libs/python/helperGeneric.py
@@ -180,7 +180,11 @@ def getDictWithEnvVariables(btpUsecase):
     if btpUsecase.envvariables is not None and len(btpUsecase.envvariables) > 0:
         for variable, value in btpUsecase.envvariables.items():
             os.environ[variable] = value
-        result = dict(os.environ)
+    if btpUsecase.accountMetadata is not None and len(btpUsecase.accountMetadata) > 0:
+        for variable, value in btpUsecase.accountMetadata.items():
+            if isinstance(value, str):
+                os.environ[variable.upper()] = value
+    result = dict(os.environ)
 
     return result
 

--- a/libs/python/helperRolesAndUsers.py
+++ b/libs/python/helperRolesAndUsers.py
@@ -329,11 +329,15 @@ def assignUsersToEnvironments(btpUsecase):
                     for rolecollection in rolecollectionsCloudFoundryOrg:
                         members = getMembersForRolecollection(
                             btpUsecase, rolecollection)
+                        idp = determineIdpForRoleCollection(
+                            btpUsecase, rolecollection)
                         orgRole = rolecollection.get("name")
                         log.info("assign users to org role >" + orgRole + "<")
                         for admin in members:
                             message = " - user >" + admin + "<"
                             command = "cf set-org-role '" + admin + "' '" + org + "' '" + orgRole + "'"
+                            if idp is not None:
+                                command += " --origin '" + idp + "'"
                             p = runShellCommandFlex(
                                 btpUsecase, command, "INFO", message, False, False)
                             result = p.stdout.decode()
@@ -348,6 +352,8 @@ def assignUsersToEnvironments(btpUsecase):
                     for rolecollection in rolecollectionsCloudFoundrySpace:
                         members = getMembersForRolecollection(
                             btpUsecase, rolecollection)
+                        idp = determineIdpForRoleCollection(
+                            btpUsecase, rolecollection)
                         spaceRole = rolecollection.get("name")
                         log.info("assign users to space role >" +
                                  spaceRole + "<")
@@ -355,6 +361,8 @@ def assignUsersToEnvironments(btpUsecase):
                             message = " - user >" + admin + "<"
                             command = "cf set-space-role '" + admin + "' '" + \
                                 org + "' '" + cfspacename + "' '" + spaceRole + "'"
+                            if idp is not None:
+                                command += " --origin '" + idp + "'"
                             p = runShellCommandFlex(
                                 btpUsecase, command, "INFO", message, False, False)
                             result = p.stdout.decode()


### PR DESCRIPTION
**Reason**

In some cases, the same user exists in more than one identity provider. A common case could be a user existing in both the default SAP ID service and in an Identity Authentication service.

In those cases, `cf set-org-role` and `cf set-space-role` will not assign the user, as it doesn't know which user to choose from. The error it gives is:

```
Ambiguous user. User with username 'xxxxxxxx' exists in the following origins: sap.ids, xxxx, xxxx. Specify an origin to disambiguate.
FAILED
```

According to the [`cf set-org-role`](https://cli.cloudfoundry.org/en-US/v7/set-org-role.html) and [`cf set-space-role`](https://cli.cloudfoundry.org/en-US/v7/set-space-role.html), you can use the option `--origin <idp>` to specify the idp of the user.

I added the same logic applied to the idp for the btp roles so that it only adds the option if they have set the property _idp_.

Thanks,
Pedro