### PR TITLE
add origin to cf roles

### DIFF
--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -4,7 +4,7 @@ certifi==2022.9.24
 charset-normalizer==2.1.1
 flake8==4.0.1
 idna==3.4
-inquirer==3.0.0
+inquirer==2.10.1
 Jinja2==3.1.2
 jsonschema==4.17.0
 MarkupSafe==2.1.1

--- a/config/python/requirements.txt
+++ b/config/python/requirements.txt
@@ -4,7 +4,7 @@ certifi==2022.9.24
 charset-normalizer==2.1.1
 flake8==4.0.1
 idna==3.4
-inquirer==2.10.1
+inquirer==3.0.0
 Jinja2==3.1.2
 jsonschema==4.17.0
 MarkupSafe==2.1.1

--- a/libs/python/helperRolesAndUsers.py
+++ b/libs/python/helperRolesAndUsers.py
@@ -329,11 +329,15 @@ def assignUsersToEnvironments(btpUsecase):
                     for rolecollection in rolecollectionsCloudFoundryOrg:
                         members = getMembersForRolecollection(
                             btpUsecase, rolecollection)
+                        idp = determineIdpForRoleCollection(
+                            btpUsecase, rolecollection)
                         orgRole = rolecollection.get("name")
                         log.info("assign users to org role >" + orgRole + "<")
                         for admin in members:
                             message = " - user >" + admin + "<"
                             command = "cf set-org-role '" + admin + "' '" + org + "' '" + orgRole + "'"
+                            if idp is not None:
+                                command += " --origin '" + idp + "'"
                             p = runShellCommandFlex(
                                 btpUsecase, command, "INFO", message, False, False)
                             result = p.stdout.decode()
@@ -348,6 +352,8 @@ def assignUsersToEnvironments(btpUsecase):
                     for rolecollection in rolecollectionsCloudFoundrySpace:
                         members = getMembersForRolecollection(
                             btpUsecase, rolecollection)
+                        idp = determineIdpForRoleCollection(
+                            btpUsecase, rolecollection)
                         spaceRole = rolecollection.get("name")
                         log.info("assign users to space role >" +
                                  spaceRole + "<")
@@ -355,6 +361,8 @@ def assignUsersToEnvironments(btpUsecase):
                             message = " - user >" + admin + "<"
                             command = "cf set-space-role '" + admin + "' '" + \
                                 org + "' '" + cfspacename + "' '" + spaceRole + "'"
+                            if idp is not None:
+                                command += " --origin '" + idp + "'"
                             p = runShellCommandFlex(
                                 btpUsecase, command, "INFO", message, False, False)
                             result = p.stdout.decode()


### PR DESCRIPTION
**Reason**

In some cases, the same user exists in more than one identity provider. A common case could be a user existing in both the default SAP ID service and in an Identity Authentication service.

In those cases, `cf set-org-role` and `cf set-space-role` will not assign the user, as it doesn't know which user to choose from. The error it gives is:

```
Ambiguous user. User with username 'xxxxxxxx' exists in the following origins: sap.ids, xxxx, xxxx. Specify an origin to disambiguate.
FAILED
```

According to the [`cf set-org-role`](https://cli.cloudfoundry.org/en-US/v7/set-org-role.html) and [`cf set-space-role`](https://cli.cloudfoundry.org/en-US/v7/set-space-role.html), you can use the option `--origin <idp>` to specify the idp of the user.

I added the same logic applied to the idp for the btp roles so that it only adds the option if they have set the property _idp_.

Thanks,
Pedro