### PR TITLE
Subaccount enable beta features

### DIFF
--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -156,6 +156,12 @@
             "title": "list of environment variables on OS level to be used within commands defined in the `executeBeforeAccountSetup` and `executeAfterAccountSetup`.",
             "default": null
         },
+        "subaccountenablebeta": {
+            "type": "boolean",
+            "description": "if set to true, a newly create subaccount will have beta features enabled",
+            "title": "enable beta features in new subaccount",
+            "default": true
+        },
         "fallbackserviceplan": {
             "type": [
                 "string",

--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -160,7 +160,7 @@
             "type": "boolean",
             "description": "if set to true, a newly create subaccount will have beta features enabled",
             "title": "enable beta features in new subaccount",
-            "default": true
+            "default": false
         },
         "fallbackserviceplan": {
             "type": [

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -156,6 +156,12 @@
             "title": "list of environment variables on OS level to be used within commands defined in the `executeBeforeAccountSetup` and `executeAfterAccountSetup`.",
             "default": null
         },
+        "subaccountenablebeta": {
+            "type": "boolean",
+            "description": "if set to true, a newly create subaccount will have beta features enabled",
+            "title": "enable beta features in new subaccount",
+            "default": true
+        },
         "fallbackserviceplan": {
             "type": [
                 "string",

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -160,7 +160,7 @@
             "type": "boolean",
             "description": "if set to true, a newly create subaccount will have beta features enabled",
             "title": "enable beta features in new subaccount",
-            "default": true
+            "default": false
         },
         "fallbackserviceplan": {
             "type": [

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -153,7 +153,7 @@ class BTPUSECASE:
                 if self.directorylabels is not None:
                     labelsAsString = json.dumps(self.subaccountlabels)
                     command += " --labels '" + labelsAsString + "'"
-                       
+
                 message = "Create directory >" + directory + "<"
 
                 result = runCommandAndGetJsonResult(
@@ -333,10 +333,13 @@ class BTPUSECASE:
                     --region '" + usecaseRegion + "' \
                     --subaccount-admins '" + subaccountadmins + "'"
 
+                if self.subaccountenablebeta is True:
+                    command += " --beta-enabled"
+
                 if self.subaccountlabels is not None:
                     labelsAsString = json.dumps(self.subaccountlabels)
                     command += " --labels '" + labelsAsString + "'"
-                 
+
                 message = "Create sub account >" + subaccount + "<"
 
                 if directoryid is not None and directoryid != "":


### PR DESCRIPTION
By default a newly created sub account doesn't enable beta features. This is added as a new parameter.