### PR TITLE
remove default assignment all roles for main user

### DIFF
--- a/libs/python/helperRolesAndUsers.py
+++ b/libs/python/helperRolesAndUsers.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 def getMembersForRolecollection(btpUsecase, rolecollection):
     users = []
-    users.append(btpUsecase.myemail)
+    # users.append(btpUsecase.myemail)
     if rolecollection:
         for usergroup in rolecollection.get("assignedUserGroupsFromParameterFile"):
             members = getMembersOfUserGroup(btpUsecase, usergroup)
@@ -84,7 +84,7 @@ def getRoleCollectionsOfServices(btpUsecase):
 
 def getMembersOfUserGroup(btpUsecase, usergroup):
     members = []
-    members.append(btpUsecase.myemail)
+    # members.append(btpUsecase.myemail)
     usergroupExists = False
 
     if btpUsecase.myusergroups and usergroup:

--- a/libs/python/helperRolesAndUsers.py
+++ b/libs/python/helperRolesAndUsers.py
@@ -10,8 +10,9 @@ log = logging.getLogger(__name__)
 
 
 def getMembersForRolecollection(btpUsecase, rolecollection):
+    # the one executing the use case is only added to the role collections defined in the use case if explicitly added
     users = []
-    # users.append(btpUsecase.myemail)
+
     if rolecollection:
         for usergroup in rolecollection.get("assignedUserGroupsFromParameterFile"):
             members = getMembersOfUserGroup(btpUsecase, usergroup)
@@ -83,8 +84,8 @@ def getRoleCollectionsOfServices(btpUsecase):
 
 
 def getMembersOfUserGroup(btpUsecase, usergroup):
+    # the one executing the use case is only added to the role collections defined in the use case if explicitly added
     members = []
-    # members.append(btpUsecase.myemail)
     usergroupExists = False
 
     if btpUsecase.myusergroups and usergroup:


### PR DESCRIPTION
This PR fixes issue https://github.com/SAP-samples/btp-setup-automator/issues/344 around the default assignment to all roles by the user who is calling the script. 