### PR TITLE
Skip CF space creation

### DIFF
--- a/config/templates/libs/BTPSA-PARAMETERS.json
+++ b/config/templates/libs/BTPSA-PARAMETERS.json
@@ -380,6 +380,12 @@
             "title": "switch to run default tests at the beginning of the script",
             "default": true
         },
+        "skipcfspacecreation": {
+            "type": "boolean",
+            "description": "if set to True: skips the creation of a CF space",
+            "title": "skip the creation of a CF space",
+            "default": false
+        },
         "subaccountenablebeta": {
             "type": "boolean",
             "description": "if set to true, a newly create subaccount will have beta features enabled",

--- a/libs/btpsa-parameters.json
+++ b/libs/btpsa-parameters.json
@@ -380,6 +380,12 @@
             "title": "switch to run default tests at the beginning of the script",
             "default": true
         },
+        "skipcfspacecreation": {
+            "type": "boolean",
+            "description": "if set to True: skips the creation of a CF space",
+            "title": "skip the creation of a CF space",
+            "default": false
+        },
         "subaccountenablebeta": {
             "type": "boolean",
             "description": "if set to true, a newly create subaccount will have beta features enabled",

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -482,8 +482,10 @@ class BTPUSECASE:
                             accountMetadata, "cfapiendpoint", cfApiEndpoint)
 
                         save_collected_metadata(self)
-                        self.create_new_cf_space(environment)
-                        self.create_and_assign_quota_plan(environment)
+                        
+                        if self.skipcfspacecreation is False:
+                            self.create_new_cf_space(environment)
+                            self.create_and_assign_quota_plan(environment)
 
                     else:
                         log.success("CF environment >" + org +


### PR DESCRIPTION
Enable skipping of creation CF spaces although the CF environment is created.

To ensure backward compatibility we provide a new parameter in `parameters.json` to enable this behavior. So in case you want to skip the creation of a CF space although you create a CD environment (and an org) you can set the parameter `skipcfspacecreation` to `true`.

The default value of the parameter is `false`, so all existing `parameter.json` configurations do not need to be adjusted