### PR TITLE
Fix for Issue 398

### DIFF
--- a/config/templates/libs/BTPSA-USECASE.json
+++ b/config/templates/libs/BTPSA-USECASE.json
@@ -333,6 +333,12 @@
                         "description": "parameter file for the service in case you want to provide the parameters via a file",
                         "title": "parameter file for the service"
                     },
+                    "skipTrustSetupForXSUAA": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "skip the trust setup to an IdP for XSUAA. Only relevant for the plan apiaccess!",
+                        "title": "skip trust setup to IdP for XSUAA (plan apiaccess)"
+                    },
                     "statusResponse": {
                         "type": "object",
                         "description": "information that is available only durng the execution of the script (should not be set in the usecase.json file)",

--- a/libs/btpsa-usecase.json
+++ b/libs/btpsa-usecase.json
@@ -319,6 +319,12 @@
                         "description": "parameter file for the service in case you want to provide the parameters via a file",
                         "title": "parameter file for the service"
                     },
+                    "skipTrustSetupForXSUAA": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "skip the trust setup to an IdP for XSUAA. Only relevant for the plan apiaccess!",
+                        "title": "skip trust setup to IdP for XSUAA (plan apiaccess)"
+                    },
                     "statusResponse": {
                         "type": "object",
                         "description": "information that is available only durng the execution of the script (should not be set in the usecase.json file)",

--- a/libs/python/helperBtpTrust.py
+++ b/libs/python/helperBtpTrust.py
@@ -12,7 +12,11 @@ def runTrustFlow(btpUsecase):
 
     if "createdServiceInstances" in accountMetadata:
         for service in accountMetadata["createdServiceInstances"]:
-            if service["name"] == "xsuaa" and service["plan"] == "apiaccess" and service["skipTrustSetupForXSUAA"] is False:
+            if (
+                service["name"] == "xsuaa"
+                and service["plan"] == "apiaccess"
+                and service["skipTrustSetupForXSUAA"] is False
+            ):
                 log.info("SETTING UP TRUST")
                 log.header("SETTING UP TRUST")
                 if "instancename" in service and "createdServiceKeys" in service:

--- a/libs/python/helperBtpTrust.py
+++ b/libs/python/helperBtpTrust.py
@@ -12,7 +12,7 @@ def runTrustFlow(btpUsecase):
 
     if "createdServiceInstances" in accountMetadata:
         for service in accountMetadata["createdServiceInstances"]:
-            if service["name"] == "xsuaa" and service["plan"] == "apiaccess":
+            if service["name"] == "xsuaa" and service["plan"] == "apiaccess" and service["skipTrustSetupForXSUAA"] is False:
                 log.info("SETTING UP TRUST")
                 log.header("SETTING UP TRUST")
                 if "instancename" in service and "createdServiceKeys" in service:


### PR DESCRIPTION
## Purpose

This PR makes the establishment of trust between XSUAA and an IdP more flexible. The current implementation enforces the establishment of trust between XSUAA and an IdP whenever a service instance of the XSUAA service with the plan `apiaccess` is created. Although this is the most comfortable way to setup the service with this plan, there are sceanrios where this is not a desired setups (see discussion [Skip "SETTING UP TRUST" step](https://github.com/SAP-samples/btp-setup-automator/discussions/394))

This PR introduces a new parameter in the `usecase.json` namely `"skipTrustSetupForXSUAA"` which allows the caller to define if the setup should be stablished or not. To stay backwards compatible the default value is `false`.

>> This parameter is only relevant for the service-plan combination **XSUAA - apiaccess**

The code is adjusted to consider this new option when setting up the trust. 

## Does the PR solve an issue

```
[X] Yes - #398 
[ ] No
```


## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Execute the setup of an XSUAA service with the plan `apiaccess`:

```json
 "name": "xsuaa",
            "plan": "apiaccess",
            "instancename": "idm_arm",
            "category": "SERVICE",
            "createServiceKeys": [
		        "idm_arm"
		      ]
```


## What to Check

Verify that the following are valid

* If the parameter `"skipTrustSetupForXSUAA"` is set to `true` no trust flow for connecting to an IdP is executed, if set to `false` or omitted in the `usecase.json` file the trust flow is executed.

## Other Information

n.a.