### PR TITLE
Add provisioning method

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1780,25 +1780,6 @@ def doAllEntitlements(btpUsecase: BTPUSECASE, allItems):
         assign_entitlement(btpUsecase, service)
 
 
-def getListOfAvailableServicesAndAppsInSubaccount(btpUsecase):
-    accountMetadata = btpUsecase.accountMetadata
-    subaccountid = accountMetadata["subaccountid"]
-
-    command = (
-        "btp --format json list accounts/entitlement --subaccount '"
-        + subaccountid
-        + "'"
-    )
-    message = (
-        "Get list of available services and app subsciptions for defined subaccount >"
-        + subaccountid
-        + "<"
-    )
-    result = runCommandAndGetJsonResult(btpUsecase, command, "INFO", message)
-
-    return result
-
-
 def isProvisioningRequired(service, allEntitlements):
     for entitlement in allEntitlements.get("quotas"):
         if entitlement.get("service") == service.name and entitlement.get("plan") == service.plan: 
@@ -1817,7 +1798,6 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
     ):
 
         log.header("Initiate subscriptions to apps")
-        entitlements = getListOfAvailableServicesAndAppsInSubaccount(btpUsecase)
 
         # Now do all the subscriptions
         for appSubscription in btpUsecase.definedAppSubscriptions:
@@ -1825,14 +1805,7 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters
             if appSubscription.entitleonly is False:
-                provisioningRequired = isProvisioningRequired(appSubscription, allEntitlements=entitlements)
-                if provisioningRequired is True:
-                    subscribe_app_to_subaccount(btpUsecase, appName, appPlan, parameters)
-                if isProvisioningRequired(appSubscription, allEntitlements=entitlements) is False:
-                    log.warning("Creation of subscription not required for app >" + appSubscription.name + "< and plan >" + appSubscription.plan  + "<. Skipping.")
-                if isProvisioningRequired(appSubscription, allEntitlements=entitlements) is None:
-                    log.error("Something wrong with entitlement for app >" + appSubscription.name + "< and plan >" + appSubscription.plan  + "<. Please cross-check!")
-                    sys.exit(os.EX_DATAERR)
+                subscribe_app_to_subaccount(btpUsecase, appName, appPlan, parameters)
 
 
 def get_subscription_deletion_status(btpUsecase: BTPUSECASE, app):

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -2009,7 +2009,7 @@ def pruneSubaccount(btpUsecase: BTPUSECASE):
         + accountMetadata["subaccountid"]
         + "' --global-account '"
         + btpUsecase.globalaccount
-        + "' --confirm"
+        + "' --confirm --force-delete"
     )
     message = "Delete sub account"
     result = runShellCommand(btpUsecase, command, "INFO", message)
@@ -2230,7 +2230,7 @@ def pruneUseCaseAssets(btpUsecase: BTPUSECASE):
     for environment in btpUsecase.definedEnvironments:
         if environment.name == "cloudfoundry":
             log.info(
-                "Cloud Foundry envorinment will be deleted automatically with the deletion of the sub account. No separate deletion needed."
+                "Cloud Foundry envorinment will be deleted automatically with the deletion of the sub account (prunesubaccount was set to true)"
             )
 
         if environment.name == "kymaruntime":

--- a/libs/python/helperServiceInstances.py
+++ b/libs/python/helperServiceInstances.py
@@ -1,4 +1,4 @@
-from libs.python.helperCommandExecution import runShellCommand
+from libs.python.helperCommandExecution import runShellCommand, runCommandAndGetJsonResult
 from libs.python.helperGeneric import (
     getServiceByServiceName,
     createInstanceName,
@@ -27,6 +27,7 @@ from libs.python.helperEnvBTP import (
     deleteBtpServiceInstance,
     getBtpServiceDeletionStatus,
 )
+
 from libs.python.helperEnvKyma import (
     createKymaServiceBinding,
     deleteKymaServiceBindingAndWait,
@@ -229,6 +230,17 @@ def checkIfAllServiceInstancesCreated(btpUsecase, checkIntervalInSeconds):
     return allServicesCreated
 
 
+def isProvisioningRequired(service, allEntitlements):
+    for entitlement in allEntitlements.get("quotas"):
+        if entitlement.get("service") == service.name and entitlement.get("plan") == service.plan: 
+            if entitlement.get("provisioningMethod") == "NONE_REQUIRED":
+                return False
+            if entitlement.get("provisioningMethod") == "SERVICE_BROKER":
+                return True
+    
+    return None
+        
+
 def initiateCreationOfServiceInstances(btpUsecase):
     createServiceInstances = (
         btpUsecase.definedServices is not None and len(btpUsecase.definedServices) > 0
@@ -236,6 +248,8 @@ def initiateCreationOfServiceInstances(btpUsecase):
 
     if createServiceInstances is True:
         log.header("Initiate creation of service instances")
+
+
 
         # First add all instance names to the services
         for service in btpUsecase.definedServices:
@@ -259,12 +273,23 @@ def initiateCreationOfServiceInstances(btpUsecase):
                 )
                 sys.exit(os.EX_DATAERR)
 
+        entitlements = getListOfAvailableServicesAndAppsInSubaccount(btpUsecase)
+
         serviceInstancesToBeCreated = []
         # Restrict the creation of service instances to those
         # that have been set to entitleOnly to False (default)
         for service in btpUsecase.definedServices:
+
+            # Check whether the creation of a service instance is required at all
+            provisioningRequired = isProvisioningRequired(service, allEntitlements=entitlements)
             if service.entitleonly is False:
-                serviceInstancesToBeCreated.append(service)
+                if isProvisioningRequired(service, allEntitlements=entitlements) is True:
+                    serviceInstancesToBeCreated.append(service)
+                if isProvisioningRequired(service, allEntitlements=entitlements) is False:
+                    log.warning("Creation of service instance not required for service >" + service.name + "< and plan >" + service.plan  + "<. Skipping.")
+                if isProvisioningRequired(service, allEntitlements=entitlements) is None:
+                    log.error("Something wrong with entitlement for service >" + service.name + "< and plan >" + service.plan  + "<. Please cross-check!")
+                    sys.exit(os.EX_DATAERR)
 
         # Now create all the service instances
         for service in serviceInstancesToBeCreated:
@@ -360,6 +385,24 @@ def get_service_status(btpUsecase, service, targetEnvironment):
 
     return status
 
+
+def getListOfAvailableServicesAndAppsInSubaccount(btpUsecase):
+    accountMetadata = btpUsecase.accountMetadata
+    subaccountid = accountMetadata["subaccountid"]
+
+    command = (
+        "btp --format json list accounts/entitlement --subaccount '"
+        + subaccountid
+        + "'"
+    )
+    message = (
+        "Get list of available services and app subsciptions for defined subaccount >"
+        + subaccountid
+        + "<"
+    )
+    result = runCommandAndGetJsonResult(btpUsecase, command, "INFO", message)
+
+    return result
 
 def createServiceInstance(btpUsecase, service, targetEnvironment, serviceCategory):
     if targetEnvironment == "cloudfoundry":


### PR DESCRIPTION
## Purpose

This PR includes the handling of services not requiring the creation of a service instance ("provisioningMethod": "NONE_REQUIRED").

In addition this PR adds a --force-delete capability to prune a sub account, as the recent changes in the BTP have made this necessary (sub account can't be deleted with existing environment instances).


## Does the PR solve an issue
```
[x] Yes - [see issue for "plan not found"](https://github.com/SAP-samples/btp-setup-automator/issues/432)
[ ] No
```


## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Enabling a service that has the provisioningMethod set to "NONE_REQUIRED", should not initiate the creation of a service instance.

## Other Information
<!-- Add any other helpful information that may be needed here. -->