### PR TITLE
Exit if instance cant create

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1109,7 +1109,7 @@ class BTPUSECASE:
         accountMetadata = self.accountMetadata
 
         if (
-            "createdServiceInstances" in accountMetadata
+            accountMetadata is not None and "createdServiceInstances" in accountMetadata
             and len(accountMetadata["createdServiceInstances"]) > 0
         ):
             log.header("Create service keys if configured")
@@ -1961,6 +1961,7 @@ def track_creation_of_subscriptions_and_services(btpUsecase: BTPUSECASE):
     log.error(
         "Could not get all services and/or app subscriptions up and running. Sorry."
     )
+    sys.exit(os.EX_NOTFOUND)
 
 
 def addCreatedServicesToMetadata(btpUsecase: BTPUSECASE):


### PR DESCRIPTION
## Purpose

In case a service instance can't be created, currently the btp-setup-automator moves on, and might run into several unforseen states in the code. Therefore, this PR stops the execution of the btp-setup-automator for such cases.

## Does the PR solve an issue

```
[ ] Yes - Please add issue number
[x] No
```


## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Very difficult, as this case only happens in those cases, where the creation of a service instance runs into a timeout.

## What to Check

None.

## Other Information
<!-- Add any other helpful information that may be needed here. -->