### PR TITLE
implement proper handling of appName for apps

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -12,6 +12,7 @@ from libs.python.helperCommandExecution import (
     executeCommandsFromUsecaseFile,
     runShellCommand,
     runCommandAndGetJsonResult,
+    runCommandFlexAndGetJsonResult,
     runShellCommandFlex,
     login_btp,
     login_cf,
@@ -1733,7 +1734,7 @@ def subscribe_app_to_subaccount(btpUsecase: BTPUSECASE, app, plan, parameters):
             # (Optional) The subscription plan of the multitenant application. You can omit this parameter if the multitenant application is in the current global account.
             message = message + " and plan >" + plan + "<"
 
-        log.info(message)
+        log.success(message)
 
 
 # determine the "appName" for a "commercialAppName"
@@ -1747,7 +1748,7 @@ def getAppNameForCommercialAppName(btpUsecase: BTPUSECASE, commercialAppName: st
         + subaccountid
         + "'"
     )
-    resultCommand = runCommandAndGetJsonResult(
+    resultCommand = runCommandFlexAndGetJsonResult(
         btpUsecase, command, "INFO", "get appName for commercialAppName"
     )
 
@@ -1758,7 +1759,7 @@ def getAppNameForCommercialAppName(btpUsecase: BTPUSECASE, commercialAppName: st
     ):
         for entry in resultCommand.get("applications"):
             if entry.get("commercialAppName") == commercialAppName:
-                result = entry.get("appName")
+                result = str(entry.get("appName"))
 
     return result
 
@@ -1781,7 +1782,7 @@ def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, commercialAppName, appPlan):
         command = command + " --plan '" + appPlan + "'"
 
     resultCommand = runCommandAndGetJsonResult(
-        btpUsecase, command, "INFO", "check if app already subscribed", False
+        btpUsecase, command, "INFO", "check if app already subscribed"
     )
 
     if (
@@ -1840,8 +1841,12 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
             appName = getAppNameForCommercialAppName(btpUsecase, appSubscription.name)
             # In case the appName and commercialAppName differ ...
             if appName != commercialAppName:
+                log.success("appName for app subscription >" + commercialAppName + "< is called >" + appName + "<")
                 # ... use from here on the appName in the tooling (overwrite the configured name)
                 appSubscription.name = appName
+            else:
+                log.success("appName and commercialAppName are the same for >" + commercialAppName + "<")
+
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters
             if appSubscription.entitleonly is False:

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1836,8 +1836,11 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
         # Now do all the subscriptions
         for appSubscription in btpUsecase.definedAppSubscriptions:
             commercialAppName = appSubscription.name
+            # Detect whether there is a difference between appName and commercialAppName
             appName = getAppNameForCommercialAppName(btpUsecase, appSubscription.name)
+            # In case the appName and commercialAppName differ ...
             if appName != commercialAppName:
+                # ... use from here on the appName in the tooling (overwrite the configured name)
                 appSubscription.name = appName
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1841,11 +1841,21 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
             appName = getAppNameForCommercialAppName(btpUsecase, appSubscription.name)
             # In case the appName and commercialAppName differ ...
             if appName != commercialAppName:
-                log.success("appName for app subscription >" + commercialAppName + "< is called >" + appName + "<")
+                log.success(
+                    "appName for app subscription >"
+                    + commercialAppName
+                    + "< is called >"
+                    + appName
+                    + "<"
+                )
                 # ... use from here on the appName in the tooling (overwrite the configured name)
                 appSubscription.name = appName
             else:
-                log.success("appName and commercialAppName are the same for >" + commercialAppName + "<")
+                log.success(
+                    "appName and commercialAppName are the same for >"
+                    + commercialAppName
+                    + "<"
+                )
 
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1744,13 +1744,18 @@ def getAppNameForCommercialAppName(btpUsecase: BTPUSECASE, commercialAppName: st
 
     command = (
         "btp --format json list accounts/subscription --subaccount '"
-        + subaccountid + "'"
+        + subaccountid
+        + "'"
     )
     resultCommand = runCommandAndGetJsonResult(
         btpUsecase, command, "INFO", "get appName for commercialAppName"
     )
 
-    if resultCommand is not None and len(resultCommand) > 0 and resultCommand.get("applications"):
+    if (
+        resultCommand is not None
+        and len(resultCommand) > 0
+        and resultCommand.get("applications")
+    ):
         for entry in resultCommand.get("applications"):
             if entry.get("commercialAppName") == commercialAppName:
                 result = entry.get("appName")
@@ -1779,7 +1784,11 @@ def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, commercialAppName, appPlan):
         btpUsecase, command, "INFO", "check if app already subscribed", False
     )
 
-    if resultCommand is not None and "state" in resultCommand and resultCommand["state"] == "SUBSCRIBED":
+    if (
+        resultCommand is not None
+        and "state" in resultCommand
+        and resultCommand["state"] == "SUBSCRIBED"
+    ):
         result = True
 
     return result

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -235,10 +235,17 @@ def checkIfCfEnvironmentIsDefined(btpUsecase):
     return False
 
 
-def runCommandAndGetJsonResult(
+def runCommandFlexAndGetJsonResult(
     btpUsecase, command, format, message, exitIfError: bool = True
 ):
-    p = runShellCommand(btpUsecase, command, format, message, exitIfError)
+    p = runShellCommandFlex(btpUsecase, command, format, message, exitIfError, False)
+    list = p.stdout.decode()
+    list = convertStringToJson(list)
+    return list
+
+def runCommandAndGetJsonResult(
+    btpUsecase, command, format, message):
+    p = runShellCommand(btpUsecase, command, format, message)
     list = p.stdout.decode()
     list = convertStringToJson(list)
     return list

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -137,7 +137,7 @@ def runShellCommandFlex(btpUsecase, command, format, info, exitIfError, noPipe):
         for passwordString in passwordStrings:
             if passwordString in command:
                 commandToBeLogged = (
-                    command[0 : command.index(passwordString) + len(passwordString) + 1]
+                    command[0: command.index(passwordString) + len(passwordString) + 1]
                     + "xxxxxxxxxxxxxxxxx"
                 )
                 log.command(commandToBeLogged)
@@ -235,7 +235,9 @@ def checkIfCfEnvironmentIsDefined(btpUsecase):
     return False
 
 
-def runCommandAndGetJsonResult(btpUsecase, command, format, message, exitIfError: bool = True):
+def runCommandAndGetJsonResult(
+    btpUsecase, command, format, message, exitIfError: bool = True
+):
     p = runShellCommand(btpUsecase, command, format, message, exitIfError)
     list = p.stdout.decode()
     list = convertStringToJson(list)

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -9,8 +9,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def runShellCommand(btpUsecase, command, format, info, exitIfError: bool = True):
-    return runShellCommandFlex(btpUsecase, command, format, info, exitIfError, False)
+def runShellCommand(btpUsecase, command, format, info):
+    return runShellCommandFlex(btpUsecase, command, format, info, True, False)
 
 
 def login_cf(btpUsecase):
@@ -137,7 +137,7 @@ def runShellCommandFlex(btpUsecase, command, format, info, exitIfError, noPipe):
         for passwordString in passwordStrings:
             if passwordString in command:
                 commandToBeLogged = (
-                    command[0: command.index(passwordString) + len(passwordString) + 1]
+                    command[0 : command.index(passwordString) + len(passwordString) + 1]
                     + "xxxxxxxxxxxxxxxxx"
                 )
                 log.command(commandToBeLogged)
@@ -243,8 +243,8 @@ def runCommandFlexAndGetJsonResult(
     list = convertStringToJson(list)
     return list
 
-def runCommandAndGetJsonResult(
-    btpUsecase, command, format, message):
+
+def runCommandAndGetJsonResult(btpUsecase, command, format, message):
     p = runShellCommand(btpUsecase, command, format, message)
     list = p.stdout.decode()
     list = convertStringToJson(list)

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -9,8 +9,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def runShellCommand(btpUsecase, command, format, info):
-    return runShellCommandFlex(btpUsecase, command, format, info, True, False)
+def runShellCommand(btpUsecase, command, format, info, exitIfError: bool = True):
+    return runShellCommandFlex(btpUsecase, command, format, info, exitIfError, False)
 
 
 def login_cf(btpUsecase):
@@ -235,8 +235,8 @@ def checkIfCfEnvironmentIsDefined(btpUsecase):
     return False
 
 
-def runCommandAndGetJsonResult(btpUsecase, command, format, message):
-    p = runShellCommand(btpUsecase, command, format, message)
+def runCommandAndGetJsonResult(btpUsecase, command, format, message, exitIfError: bool = True):
+    p = runShellCommand(btpUsecase, command, format, message, exitIfError)
     list = p.stdout.decode()
     list = convertStringToJson(list)
     return list

--- a/libs/python/helperJson.py
+++ b/libs/python/helperJson.py
@@ -112,8 +112,10 @@ def dictToJson(dict):
 
 
 def convertStringToJson(string):
-    jsonObject = json.loads(string)
-    return jsonObject
+    result = None
+    if string is not None and len(string) > 0:
+        result = json.loads(string)
+    return result
 
 
 def addKeyValuePair(json, key, value):


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR implements a proper handling of app subscriptions that have an appName that differs from the commercialAppName.

## Does the PR solve an issue
<!-- Mark one with an "x". -->

```
[ ] Yes - Please add issue number
[x] No
```


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->
Add the app subscription for "integrationsuite". Without this PR the btp-setup-automator won't find the respective app subscription in your sub account, as the appName differs from the commercialAppName.

## What to Check

Verify that the following are valid

- The app subsucription works for integrationsuite

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Once "slim" integration test is done, I'll request a review for the updated code.