### PR TITLE
feat: additional parameter files

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -12,6 +12,7 @@ from libs.python.helperCommandExecution import (
     executeCommandsFromUsecaseFile,
     runShellCommand,
     runCommandAndGetJsonResult,
+    runCommandFlexAndGetJsonResult,
     runShellCommandFlex,
     login_btp,
     login_cf,
@@ -143,14 +144,6 @@ class BTPUSECASE:
         save_collected_metadata(self)
         checkConfigurationInfo(self)
 
-    def __contains__(self, x):
-        # Check for certain parameters
-        try:
-            test = self[x]
-            return True
-        except Error:
-            return False
-
     def outputCurrentBtpUsecaseVariables(self):
         # First detect the maximum string length of the parameter and values
         maxLenParameter = 0
@@ -194,7 +187,6 @@ class BTPUSECASE:
                 log.success("Use case supported in your global account!")
 
     def create_directory(self):
-
         if self.usedirectory is False:
             # Do not create a directory for the use case
             return
@@ -210,7 +202,6 @@ class BTPUSECASE:
             or accountMetadata["directoryid"] == ""
             or accountMetadata["directoryid"] is None
         ):
-
             log.warning("no directory id provided and tool will make up one for you")
 
             directory = createDirectoryName(self)
@@ -345,7 +336,6 @@ class BTPUSECASE:
                 environment.name == "kymaruntime"
                 and self.waitForKymaEnvironmentCreation is True
             ):
-
                 accountMetadata = self.accountMetadata
                 kymaClusterName = environment.parameters["name"]
 
@@ -387,7 +377,6 @@ class BTPUSECASE:
                         getKymaEnvironmentStatusFromEnvironmentDataEntry(entryOfKymaEnv)
                         == "OK"
                     ):
-
                         log.info("Kyma Environment created - extracting kubeconfig URL")
                         self.accountMetadata = addKeyValuePair(
                             accountMetadata,
@@ -445,7 +434,6 @@ class BTPUSECASE:
         doAllEntitlements(self, self.definedAppSubscriptions)
 
     def create_subaccount(self):
-
         accountMetadata = self.accountMetadata
         subaccountid = self.subaccountid
         self.accountMetadata = addKeyValuePair(
@@ -461,7 +449,6 @@ class BTPUSECASE:
             or accountMetadata["subaccountid"] == ""
             or accountMetadata["subaccountid"] is None
         ):
-
             log.warning("no subaccount id provided and tool will make up one for you")
             usecaseRegion = self.region
 
@@ -580,11 +567,9 @@ class BTPUSECASE:
         save_collected_metadata(self)
 
     def initialize_environments(self):
-
         self.create_environments()
 
     def create_environments(self):
-
         accountMetadata = self.accountMetadata
         environments = self.definedEnvironments
 
@@ -596,14 +581,11 @@ class BTPUSECASE:
             self.accountMetadata = addKeyValuePair(accountMetadata, "orgid", self.orgid)
 
         if self.orgid is None or self.orgid == "":
-
             for environment in environments:
-
                 if environment.name == "cloudfoundry":
                     orgid, org = checkIfCFEnvironmentAlreadyExists(self)
 
                     if org is None or orgid is None:
-
                         envName = environment.name
                         envPlan = environment.plan
 
@@ -875,7 +857,6 @@ class BTPUSECASE:
             foundOrg = False
             for environment in environments:
                 if environment.name == "cloudfoundry":
-
                     command = (
                         "btp --format json list accounts/environment-instances --subaccount '"
                         + subaccountid
@@ -925,7 +906,6 @@ class BTPUSECASE:
             cfEnvironment = True
 
         if cfEnvironment is True:
-
             accountMetadata = self.accountMetadata
 
             cfspacename = self.cfspacename
@@ -975,7 +955,6 @@ class BTPUSECASE:
 
     def create_and_assign_quota_plan(self, environment):
         if environment.name == "cloudfoundry" and self.cfspacequota is not None:
-
             if self.cfspacequota.get("createQuotaPlan") is True:
                 command = "cf create-space-quota " + self.cfspacequota.get(
                     "spaceQuotaName"
@@ -1094,7 +1073,6 @@ class BTPUSECASE:
         assignUsersToCustomRoleCollections(self)
 
     def create_configured_app_subscriptions_and_services(self):
-
         ##################################################################################
         # Initiate all app subscriptions
         ##################################################################################
@@ -1124,7 +1102,8 @@ class BTPUSECASE:
         accountMetadata = self.accountMetadata
 
         if (
-            accountMetadata is not None and "createdServiceInstances" in accountMetadata
+            accountMetadata is not None
+            and "createdServiceInstances" in accountMetadata
             and len(accountMetadata["createdServiceInstances"]) > 0
         ):
             log.header("Create service keys if configured")
@@ -1219,7 +1198,6 @@ def getServiceCategoryItemsFromUsecaseFile(
 def check_if_account_can_cover_use_case_for_serviceType(
     btpUsecase: BTPUSECASE, availableForAccount
 ):
-
     usecaseRegion = btpUsecase.region
     fallbackServicePlan = None
 
@@ -1237,7 +1215,6 @@ def check_if_account_can_cover_use_case_for_serviceType(
         if service.category != "CF_CUP_SERVICE":
             allServices.append(service)
     for app in btpUsecase.definedAppSubscriptions:
-
         if app.customerDeveloped is True:
             continue
 
@@ -1345,18 +1322,15 @@ def check_if_account_can_cover_use_case_for_serviceType(
 def check_if_account_can_cover_use_case_for_customapps(
     btpUsecase: BTPUSECASE, availableCustomApps
 ):
-
     usecaseSupported = True
 
     customApps = []
     # Only check custom apps as they need special handling
     for app in btpUsecase.definedAppSubscriptions:
-
         if app.customerDeveloped is True and app.category == "APPLICATION":
             customApps.append(app)
 
     if len(customApps) != 0 and len(availableCustomApps) != 0:
-
         for customApp in customApps:
             supported = False
 
@@ -1750,7 +1724,7 @@ def subscribe_app_to_subaccount(btpUsecase: BTPUSECASE, app, plan, parameters):
 
     if parameters is not None:
         # For custom apps a plan can be none - this is safeguarded when checking if account is capable of usecase
-        command = command + " --parameters '[" + dictToString(parameters) + "]'"
+        command = command + " --parameters '" + dictToString(parameters) + "'"
 
     isAlreadySubscribed = checkIfAppIsSubscribed(btpUsecase, app, plan)
     if isAlreadySubscribed is False:
@@ -1762,16 +1736,42 @@ def subscribe_app_to_subaccount(btpUsecase: BTPUSECASE, app, plan, parameters):
 
         runShellCommand(btpUsecase, command, "INFO", message)
     else:
-
         message = "subscription already there for >" + app + "<"
         if plan is not None:
             # (Optional) The subscription plan of the multitenant application. You can omit this parameter if the multitenant application is in the current global account.
             message = message + " and plan >" + plan + "<"
 
-        log.info(message)
+        log.success(message)
 
 
-def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, appName, appPlan):
+# determine the "appName" for a "commercialAppName"
+def getAppNameForCommercialAppName(btpUsecase: BTPUSECASE, commercialAppName: str):
+    result = None
+    accountMetadata = btpUsecase.accountMetadata
+    subaccountid = accountMetadata["subaccountid"]
+
+    command = (
+        "btp --format json list accounts/subscription --subaccount '"
+        + subaccountid
+        + "'"
+    )
+    resultCommand = runCommandFlexAndGetJsonResult(
+        btpUsecase, command, "INFO", "get appName for commercialAppName"
+    )
+
+    if (
+        resultCommand is not None
+        and len(resultCommand) > 0
+        and resultCommand.get("applications")
+    ):
+        for entry in resultCommand.get("applications"):
+            if entry.get("commercialAppName") == commercialAppName:
+                result = str(entry.get("appName"))
+
+    return result
+
+
+def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, commercialAppName, appPlan):
     result = False
     accountMetadata = btpUsecase.accountMetadata
     subaccountid = accountMetadata["subaccountid"]
@@ -1780,7 +1780,7 @@ def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, appName, appPlan):
         "btp --format json get accounts/subscription --subaccount '"
         + subaccountid
         + "' --of-app '"
-        + appName
+        + commercialAppName
         + "'"
     )
 
@@ -1792,14 +1792,17 @@ def checkIfAppIsSubscribed(btpUsecase: BTPUSECASE, appName, appPlan):
         btpUsecase, command, "INFO", "check if app already subscribed"
     )
 
-    if "state" in resultCommand and resultCommand["state"] == "SUBSCRIBED":
+    if (
+        resultCommand is not None
+        and "state" in resultCommand
+        and resultCommand["state"] == "SUBSCRIBED"
+    ):
         result = True
 
     return result
 
 
 def doAllEntitlements(btpUsecase: BTPUSECASE, allItems):
-
     # Ensure to have a list of all entitlements as combination of service name and plan
     entitlements = []
     for service in allItems:
@@ -1836,12 +1839,31 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
         btpUsecase.definedAppSubscriptions is not None
         and len(btpUsecase.definedAppSubscriptions) > 0
     ):
-
         log.header("Initiate subscriptions to apps")
 
         # Now do all the subscriptions
         for appSubscription in btpUsecase.definedAppSubscriptions:
-            appName = appSubscription.name
+            commercialAppName = appSubscription.name
+            # Detect whether there is a difference between appName and commercialAppName
+            appName = getAppNameForCommercialAppName(btpUsecase, appSubscription.name)
+            # In case the appName and commercialAppName differ ...
+            if appName != commercialAppName:
+                log.success(
+                    "appName for app subscription >"
+                    + commercialAppName
+                    + "< is called >"
+                    + appName
+                    + "<"
+                )
+                # ... use from here on the appName in the tooling (overwrite the configured name)
+                appSubscription.name = appName
+            else:
+                log.success(
+                    "appName and commercialAppName are the same for >"
+                    + commercialAppName
+                    + "<"
+                )
+
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters
             if appSubscription.entitleonly is False:
@@ -1889,7 +1911,6 @@ def checkIfAllSubscriptionsAreAvailable(btpUsecase: BTPUSECASE):
 
     allSubscriptionsAvailable = True
     for app in btpUsecase.definedAppSubscriptions:
-
         if app.entitleonly is False:
             for thisJson in resultCommand["applications"]:
                 name = thisJson.get("appName")
@@ -1976,7 +1997,7 @@ def track_creation_of_subscriptions_and_services(btpUsecase: BTPUSECASE):
     log.error(
         "Could not get all services and/or app subscriptions up and running. Sorry."
     )
-    sys.exit(os.EX_NOTFOUND)
+    sys.exit(os.EX_DATAERR)
 
 
 def addCreatedServicesToMetadata(btpUsecase: BTPUSECASE):
@@ -2010,7 +2031,6 @@ def addCreatedServicesToMetadata(btpUsecase: BTPUSECASE):
 
 
 def checkConfigurationInfo(btpUsecase: BTPUSECASE):
-
     # checkEmailsinUsecaseConfig(btpUsecase)
     None
 

--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -727,9 +727,11 @@ class BTPUSECASE:
                     # Support load via dynamic parameter file as well
                     if environment.parameters is None:
                         # try via serviceparameter file
-                        command = f"cat \"{environment.serviceparameterfile}\""
-                        message = "Read out environment parameter fie"
-                        environment.parameters = runCommandAndGetJsonResult(self, command, "INFO", message)
+                        command = f'cat "{environment.serviceparameterfile}"'
+                        message = "Read out environment parameter file"
+                        environment.parameters = runCommandAndGetJsonResult(
+                            self, command, "INFO", message
+                        )
 
                     kymaClusterName = environment.parameters["name"]
 

--- a/libs/python/helperEnvBTP.py
+++ b/libs/python/helperEnvBTP.py
@@ -1,10 +1,14 @@
-from libs.python.helperGeneric import getTimingsForStatusRequest
-from libs.python.helperCommandExecution import runShellCommand, runShellCommandFlex
-from libs.python.helperJson import convertStringToJson, dictToString
 import logging
 import os
 import sys
 import time
+
+from libs.python.helperCommandExecution import runShellCommand, runShellCommandFlex
+from libs.python.helperEnvironments import (
+    check_if_service_plan_supported_in_environment,
+)
+from libs.python.helperGeneric import getTimingsForStatusRequest
+from libs.python.helperJson import convertStringToJson, dictToString
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +31,13 @@ def get_btp_service_status(btpUsecase, service):
     return result
 
 
+def check_if_service_plan_supported_in_sapbtp(btpUsecase, service):
+    result = check_if_service_plan_supported_in_environment(
+        btpUsecase, service, "sapbtp"
+    )
+    return result
+
+
 def create_btp_service(btpUsecase, service):
     if is_service_instance_already_existing(btpUsecase, service) is True:
         log.info(
@@ -35,6 +46,16 @@ def create_btp_service(btpUsecase, service):
             + "< already exists and won't be created newly."
         )
         return
+
+    if check_if_service_plan_supported_in_sapbtp(btpUsecase, service) is False:
+        log.error(
+            "Plan not supported in environment >sapbtp<: service >"
+            + service.name
+            + "< and plan >"
+            + service.plan
+            + "<."
+        )
+        sys.exit(os.EX_DATAERR)
 
     command = (
         "btp --format json create services/instance --subaccount "

--- a/libs/python/helperEnvBTP.py
+++ b/libs/python/helperEnvBTP.py
@@ -1,14 +1,10 @@
+from libs.python.helperGeneric import getTimingsForStatusRequest
+from libs.python.helperCommandExecution import runShellCommand, runShellCommandFlex
+from libs.python.helperJson import convertStringToJson, dictToString
 import logging
 import os
 import sys
 import time
-
-from libs.python.helperCommandExecution import runShellCommand, runShellCommandFlex
-from libs.python.helperEnvironments import (
-    check_if_service_plan_supported_in_environment,
-)
-from libs.python.helperGeneric import getTimingsForStatusRequest
-from libs.python.helperJson import convertStringToJson, dictToString
 
 log = logging.getLogger(__name__)
 
@@ -31,13 +27,6 @@ def get_btp_service_status(btpUsecase, service):
     return result
 
 
-def check_if_service_plan_supported_in_sapbtp(btpUsecase, service):
-    result = check_if_service_plan_supported_in_environment(
-        btpUsecase, service, "sapbtp"
-    )
-    return result
-
-
 def create_btp_service(btpUsecase, service):
     if is_service_instance_already_existing(btpUsecase, service) is True:
         log.info(
@@ -46,16 +35,6 @@ def create_btp_service(btpUsecase, service):
             + "< already exists and won't be created newly."
         )
         return
-
-    if check_if_service_plan_supported_in_sapbtp(btpUsecase, service) is False:
-        log.error(
-            "Plan not supported in environment >sapbtp<: service >"
-            + service.name
-            + "< and plan >"
-            + service.plan
-            + "<."
-        )
-        sys.exit(os.EX_DATAERR)
 
     command = (
         "btp --format json create services/instance --subaccount "
@@ -70,6 +49,8 @@ def create_btp_service(btpUsecase, service):
 
     if service.parameters is not None:
         command = command + " --parameters '" + dictToString(service.parameters) + "'"
+    elif service.serviceparameterfile is not None:
+        command += f" --parameters {service.serviceparameterfile}"
 
     if service.labels is not None:
         command = command + " --labels '" + dictToString(service.labels) + "'"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

I would like to enable the property `serviceparameterfile` on `sapbtp` as well on `kymaruntime` objects.

E.g. to enable this

```json
{
    "category": "ENVIRONMENT",
    "name": "kymaruntime",
    "instancename": "ccircularity-runtime",
    "plan": "aws",
    "amount": 1,
    "serviceparameterfile": "$BTPSA_PARAMETERS_SERVICE_KYMA"
}
```

or that

```json
{
    "category": "SERVICE",
    "repeatstatusrequest": 60,
    "repeatstatustimeout": 3600,
    "name": "hana-cloud",
    "plan": "hana",
    "targetenvironment": "sapbtp",
    "instancename": "ccircularity-db",
    "serviceparameterfile": "$BTPSA_PARAMETERS_SERVICE_HANA"
}
```

## Does the PR solve an issue
<!-- Mark one with an "x". -->

```
[ ] Yes - Please add issue number
[X] No
```


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->
See configuration examples above.

## What to Check

Verify that the following are valid

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->