### PR TITLE
Update UseCase file for btp-resilient-apps repo - event mesh changes + entitleonly param usage

### DIFF
--- a/usecases/released/build_resilient_apps_free_tier.json
+++ b/usecases/released/build_resilient_apps_free_tier.json
@@ -61,7 +61,14 @@
         {
             "name": "autoscaler",
             "plan": "standard",
-            "category": "SERVICE"
+            "category": "SERVICE",
+            "entitleonly": true
+        },
+        {
+            "name": "enterprise-messaging",
+            "plan": "default",
+            "category": "SERVICE",
+            "entitleonly": true
         },
         {
             "name": "hana",
@@ -93,43 +100,6 @@
             "name": "enterprise-messaging-hub",
             "plan": "standard",
             "category": "APPLICATION"
-        },
-        {
-            "name": "enterprise-messaging",
-            "plan": "default",
-            "instancename": "BusinessPartnerVerification-ems",
-            "category": "SERVICE",
-            "parameters": {
-                "resources": {
-                    "units": "10"
-                },
-                "options": {
-                    "management": true,
-                    "messagingrest": true,
-                    "messaging": true
-                },
-                "rules": {
-                    "topicRules": {
-                        "publishFilter": [
-                            "${namespace}/*"
-                        ],
-                        "subscribeFilter": [
-                            "${namespace}/*"
-                        ]
-                    },
-                    "queueRules": {
-                        "publishFilter": [
-                            "${namespace}/*"
-                        ],
-                        "subscribeFilter": [
-                            "${namespace}/*"
-                        ]
-                    }
-                },
-                "version": "1.1.0",
-                "emname": "bpem",
-                "namespace": "tfe/bpem/em12"
-            }
         },
         {
             "name": "cicd-app",


### PR DESCRIPTION
changes to entitlements (haven't used entitleonly before) + autoscaler entitlement "lite" isn't available anymore

## Purpose
updated usecase file for the resillient-apps-repo: 

- Event Mesh service-instance was created as part of the account setup + as part of the MTA deployment (thus, the emname as part of the service instance parameters were already taken)
- intro of entitleonly paramters for entitlements
- 
## Does the PR solve an issue
yes, MTA deployment wasn't succesful anymore, suddenly. thanks to @rui1610 for reporting  (no issue created)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
https://github.com/SAP-samples/btp-setup-automator/blob/main/tests/integrationtests/parameterfiles/integrationtest03.json is the file for the integrationtest

## What to Check
Integration test runs through and MTA deployment is succesful

* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->