### PR TITLE
Fix NoneType Error during app subscription

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -1865,6 +1865,8 @@ def initiateAppSubscriptions(btpUsecase: BTPUSECASE):
                     + commercialAppName
                     + "<"
                 )
+                # appname might be none, so we override it with the commercialAppName
+                appName = commercialAppName
 
             appPlan = appSubscription.plan
             parameters = appSubscription.parameters


### PR DESCRIPTION
## Purpose

* In case no app name can be detected for the commercial app name, this PR implements a fallback to use the commercial app name for the app subscription.

## Does the PR solve an issue

```
[ ] Yes - Please add issue number
[X] No
```


## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Rin the failed test for the app "tnt-onboard-dataenrichment-dcp"

## What to Check

Verify that the following are valid

* Verify that the app is subscribed correctly

## Other Information

n/a
