### PR TITLE
Fix for issue 471 - non-interactive authentication

### DIFF
--- a/libs/python/btp_cli.py
+++ b/libs/python/btp_cli.py
@@ -454,7 +454,7 @@ class BTPUSECASE:
 
             subaccount = createSubaccountName(self)
             subdomain = createSubdomainID(self)
-            
+
             log.success("using subaccount name >" + subaccount + "<")
             log.success("using subaccount domain >" + subdomain + "<")
 
@@ -469,7 +469,7 @@ class BTPUSECASE:
             )
 
             subaccountExist = checkIfSubaccountAlreadyExists(self)
-                                    
+
             if subaccountExist is None:
                 command = (
                     "btp --format json create accounts/subaccount \
@@ -544,13 +544,13 @@ class BTPUSECASE:
                     + "<"
                 )
                 self.subaccountid = subaccountid
-                self.subdomain = subdomain            
+                self.subdomain = subdomain
 
             self.accountMetadata = addKeyValuePair(
-                accountMetadata, "subaccountid", subaccountid            
+                accountMetadata, "subaccountid", subaccountid
             )
             self.accountMetadata = addKeyValuePair(
-                accountMetadata, "subdomain", subdomain            
+                accountMetadata, "subdomain", subdomain
             )
 
             self.subaccountid = subaccountid
@@ -1397,7 +1397,7 @@ def checkIfSubaccountAlreadyExists(btpUsecase: BTPUSECASE):
         + "'"
     )
     result = runCommandAndGetJsonResult(btpUsecase, command, "INFO", None)
-    
+
     if "subaccount" in accountMetadata:
         subaccountName = accountMetadata["subaccount"]
 

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -67,7 +67,7 @@ def login_cf(btpUsecase):
             runShellCommandFlex(btpUsecase, command, "INFO", message, True, pipe)
 
             # Step 2 - login
-            command = "cf auth " + myemail + " " + password + " -s " + org + " -o " + org
+            command = "cf auth " + myemail + " " + password
             message = (
                 "Non-interactive login step 2: authenticate to CF with user >"
                 + myemail

--- a/libs/python/helperCommandExecution.py
+++ b/libs/python/helperCommandExecution.py
@@ -165,6 +165,9 @@ def runShellCommandFlex(btpUsecase, command, format, info, exitIfError, noPipe):
                 log.command(commandToBeLogged)
                 foundPassword = True
                 break
+        if "cf auth" in command:
+            log.command("cf auth xxxxxxxxxxxxxxxxx")
+            foundPassword = True
         if foundPassword is False:
             log.command(command)
     p = None


### PR DESCRIPTION
## Purpose

* This PR changes the login procedure for non-SSO to the non-interactive flow (= avoiding the usage of `cf login`) to enable the handling of several CF spaces
* Fixes #471 

## Does the PR solve an issue

```
[X] Yes - Please add issue number: #471 
[ ] No
```


## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Execute the setup of a CF space in a subaccount that already hosts several CF spaces and use basic authentication for the login flow.

## What to Check

Verify that the following are valid

* The flow works without the error `inappropriate ioctl for device` that means "waiting for interactive data entry to select the space"

## Other Information

The limitation remains for login via SSO, as there is no non-interactive flow for this setup i.e. the creation of several spaces is not possible. This is an issue with the CF API and not with the btpsa.
